### PR TITLE
feat: Api documentation (springdoc, swagger)

### DIFF
--- a/piikii-input-http/build.gradle.kts
+++ b/piikii-input-http/build.gradle.kts
@@ -5,6 +5,9 @@ project(":piikii-input-http") {
         implementation("org.springframework.boot:spring-boot-starter-web")
         implementation("org.springframework.boot:spring-boot-starter-aop")
 
+        // for docs
+        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+
         // for validation
         implementation("org.springframework.boot:spring-boot-starter-validation")
     }

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/config/OpenApiConfiguration.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/config/OpenApiConfiguration.kt
@@ -1,0 +1,28 @@
+package com.piikii.input.http.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfiguration {
+    @Bean
+    fun openApi(): OpenAPI {
+        val info = Info().title(SwaggerConstant.API_NAME)
+            .version(SwaggerConstant.API_VERSION)
+            .description(SwaggerConstant.API_DESCRIPTION)
+
+        return OpenAPI()
+            .components(Components())
+            .info(info)
+    }
+
+}
+
+object SwaggerConstant {
+    const val API_NAME = "PIIKII-API"
+    const val API_VERSION = "v1"
+    const val API_DESCRIPTION = "PIIKII-API description"
+}

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/config/OpenApiConfiguration.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/config/OpenApiConfiguration.kt
@@ -8,21 +8,22 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class OpenApiConfiguration {
+
     @Bean
     fun openApi(): OpenAPI {
-        val info = Info().title(SwaggerConstant.API_NAME)
-            .version(SwaggerConstant.API_VERSION)
-            .description(SwaggerConstant.API_DESCRIPTION)
+        val info = Info().title(API_NAME)
+            .version(API_VERSION)
+            .description(API_DESCRIPTION)
 
         return OpenAPI()
             .components(Components())
             .info(info)
     }
 
-}
+    companion object {
+        const val API_NAME = "PIIKII-API"
+        const val API_VERSION = "v1"
+        const val API_DESCRIPTION = "PIIKII-API description"
+    }
 
-object SwaggerConstant {
-    const val API_NAME = "PIIKII-API"
-    const val API_VERSION = "v1"
-    const val API_DESCRIPTION = "PIIKII-API description"
 }

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/SourcePlaceApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/SourcePlaceApi.kt
@@ -1,7 +1,8 @@
-package com.piikii.input.http
+package com.piikii.input.http.controller
 
 import com.piikii.application.domain.model.sourceplace.SourcePlace
 import com.piikii.application.port.input.SourcePlaceUseCase
+import com.piikii.input.http.docs.SourcePlaceApiDocs
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
@@ -9,15 +10,16 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class SourcePlaceApi(
     private val sourcePlaceUseCase: SourcePlaceUseCase
-) {
+) : SourcePlaceApiDocs {
 
     @PostMapping("/test")
-    fun testPost(): SourcePlace {
+    override fun testPost(): SourcePlace {
         return sourcePlaceUseCase.save()
     }
 
     @GetMapping("/test")
-    fun testGet(): SourcePlace {
+    override fun testGet(): SourcePlace {
         return sourcePlaceUseCase.retrieve()
     }
+
 }

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/docs/SourcePlaceApiDocs.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/docs/SourcePlaceApiDocs.kt
@@ -1,0 +1,20 @@
+package com.piikii.input.http.docs
+
+import com.piikii.application.domain.model.sourceplace.SourcePlace
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "SourcePlaceApi", description = "SourcePlace Api 입니다.")
+interface SourcePlaceApiDocs {
+
+    @Operation(summary = "create test API", description = "sample 생성 요청 메서드")
+    @ApiResponses(value = [ApiResponse(responseCode = "201", description = "CREATED test")])
+    fun testPost(): SourcePlace
+
+    @Operation(summary = "get test API", description = "sample 조회 요청 메서드")
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "GET test")])
+    fun testGet(): SourcePlace
+    
+}

--- a/piikii-input-http/src/main/resources/http-config/application.yml
+++ b/piikii-input-http/src/main/resources/http-config/application.yml
@@ -1,0 +1,8 @@
+springdoc:
+  packages-to-scan: com.piikii.input.http
+  swagger-ui:
+    path: /api-docs
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true


### PR DESCRIPTION
for #10

Spring doc을 이용해 API Documentation을 구현합니다.
- http://localhost:8080/swagger-ui/index.html

문서화를 위한 코드가 클래스 로직 내 침범하는 것을 막기 위해 외부 인터페이스로 분리해 구현합니다.
