### PR TITLE
fix: push/pull-request CI 분리

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - develop
   pull_request:
     branches:
       - main
@@ -41,7 +37,7 @@ jobs:
         with:
           script: |
             const status = '${{ steps.set_status.outputs.build_status }}';
-            const message = status === 'success' ? '✅ 빌드 성공 ✅\n🚀👨🏻‍🚀 출격 준비 완료 👨🏻‍🚀🚀' : '❌❌ 빌드 실패 ❌❌\n😵😵‍💫 코드 확인이 필요해요 😵😵‍💫';
+            const message = status === 'success' ? '✅ 빌드 성공 ✅\n🚀 출격 준비 완료 👨🏻‍🚀' : '❌❌ 빌드 실패 ❌❌\n😵😵‍💫 코드 확인이 필요해요 😵😵‍💫';
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository 접근
+        uses: actions/checkout@v4
+
+      - name: JDK 21 셋팅
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: 프로젝트 빌드
+        env:
+          SECRET_MANAGER_TOKEN: ${{ secrets.SECRET_MANAGER_TOKEN }}
+          SECRET_MANAGER_WORKSPACE: ${{ secrets.SECRET_MANAGER_WORKSPACE }}
+        run: |
+          ./gradlew build


### PR DESCRIPTION
## 이슈

push/pull-request CI가 같으면, PR comment 다는 것 때문에 Push CI action이 실패하네요.

## 변경 사항

push/pull-request CI action을 분리했습니다.

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
