### PR TITLE
chore: PR CI when only specific comment

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,15 +1,14 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - main
-      - develop
+  issue_comment:
+    types: [ created ]
 
 jobs:
   build:
+    name: ready for launch (CI)
     runs-on: ubuntu-latest
-
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'run-action')}}
     steps:
       - name: Repository 접근
         uses: actions/checkout@v4


### PR DESCRIPTION
## 이슈

PR에 빌드코멘트가 너무 쌓이는 이슈 해결

## 변경 사항

PR 푸시가 아닌 `/출격준비` 코멘트 시에만 빌드할 수 있도록 수정합니다.

## 스크린샷

## 부연 설명

## 체크리스트

- [ ] Lint 적용 여부
- [ ] 빌드 성공 여부
- [ ] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [ ] PR에 대해 구체적으로 설명이 되어있는가
