### PR TITLE
chore: 빌드 시 캐싱된 Gradle 의존성을 사용하여 빌드 시간을 단축하도록 합니다.

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle 의존성 캐싱
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -19,6 +19,16 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Gradle 의존성 캐싱
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: 프로젝트 빌드
         env:
           SECRET_MANAGER_TOKEN: ${{ secrets.SECRET_MANAGER_TOKEN }}

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle 의존성 캐싱
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -20,6 +20,16 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Gradle 의존성 캐싱
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: 프로젝트 빌드
         env:
           SECRET_MANAGER_TOKEN: ${{ secrets.SECRET_MANAGER_TOKEN }}

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -19,6 +19,16 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Gradle 의존성 캐싱
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: 이미지 빌드 및 푸쉬
         env:
           SECRET_MANAGER_TOKEN: ${{ secrets.SECRET_MANAGER_TOKEN }}

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle 의존성 캐싱
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,15 +2,14 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id(Plugins.SPRING_BOOT) version Versions.SPRING_BOOT
-    id(Plugins.SPRING_DEPENDENCY_MANAGEMENT) version Versions.SPRING_DEPENDENCY_MANAGEMENT
-    id(Plugins.APPLICATION)
-    id(Plugins.KT_LINT) version Versions.KT_LINT_VERSION
-
-    kotlin(Plugins.JVM) version Versions.KOTLIN
-    kotlin(Plugins.SPRING) version Versions.KOTLIN
-    kotlin(Plugins.JPA) version Versions.JPA_PLUGIN
-    kotlin(Plugins.KAPT) version Versions.KAPT_PLUGIN
+    alias(libs.plugins.springBoot)
+    alias(libs.plugins.springDependencyManagement)
+    alias(libs.plugins.kotlin)
+    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlinJpa)
+    alias(libs.plugins.kotlinKapt)
+    alias(libs.plugins.ktLint)
+    application
 }
 
 allprojects {
@@ -28,26 +27,27 @@ allprojects {
 }
 
 subprojects {
-    apply(plugin = "org.jetbrains.kotlin.jvm")
-    apply(plugin = "org.jetbrains.kotlin.plugin.spring")
-    apply(plugin = "org.springframework.boot")
-    apply(plugin = "kotlin")
-    apply(plugin = "java-library")
-    apply(plugin = "kotlin-jpa")
-    apply(plugin = "io.spring.dependency-management")
-    apply(plugin = "kotlin-kapt")
-    apply(plugin = "application")
-    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+    apply {
+        plugin("org.jetbrains.kotlin.jvm")
+        plugin("org.jetbrains.kotlin.plugin.spring")
+        plugin("org.springframework.boot")
+        plugin("kotlin")
+        plugin("java-library")
+        plugin("kotlin-jpa")
+        plugin("io.spring.dependency-management")
+        plugin("kotlin-kapt")
+        plugin("application")
+        plugin("org.jlleitschuh.gradle.ktlint")
+    }
 
     dependencies {
-        // for kotlin
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
-
-        // for spring commons
         implementation("org.springframework.boot:spring-boot-autoconfigure")
         implementation("org.springframework.boot:spring-boot-starter-logging")
-        // for test
+        implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+        implementation("ch.qos.logback:logback-classic")
+
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
@@ -78,15 +78,15 @@ configure(allprojects.filter { it.name != "piikii-common" }) {
     }
 }
 
+java.toolchain.languageVersion = JavaLanguageVersion.of(libs.versions.javaVersion.get())
+
+tasks.bootJar {
+    enabled = false
+}
+
 configurations.all {
     resolutionStrategy {
         cacheDynamicVersionsFor(10 * 60, TimeUnit.SECONDS)
         cacheChangingModulesFor(4, TimeUnit.HOURS)
     }
-}
-
-java.toolchain.languageVersion = JavaLanguageVersion.of(libs.versions.javaVersion.get())
-
-tasks.bootJar {
-    enabled = false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,43 +2,52 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    alias(libs.plugins.springBoot)
-    alias(libs.plugins.springDependencyManagement)
-    alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
-    alias(libs.plugins.kotlinJpa)
-    alias(libs.plugins.kotlinKapt)
-    alias(libs.plugins.ktLint)
-    application
+    id(Plugins.SPRING_BOOT) version Versions.SPRING_BOOT
+    id(Plugins.SPRING_DEPENDENCY_MANAGEMENT) version Versions.SPRING_DEPENDENCY_MANAGEMENT
+    id(Plugins.APPLICATION)
+    id(Plugins.KT_LINT) version Versions.KT_LINT_VERSION
+
+    kotlin(Plugins.JVM) version Versions.KOTLIN
+    kotlin(Plugins.SPRING) version Versions.KOTLIN
+    kotlin(Plugins.JPA) version Versions.JPA_PLUGIN
+    kotlin(Plugins.KAPT) version Versions.KAPT_PLUGIN
 }
 
 allprojects {
     group = "com.piikii"
     version = "0.0.1-SNAPSHOT"
+
+    repositories {
+        mavenCentral()
+    }
+
+    tasks.withType<JavaCompile>().configureEach {
+        options.isIncremental = true
+        options.isFork = true
+    }
 }
 
 subprojects {
-    apply {
-        plugin("org.jetbrains.kotlin.jvm")
-        plugin("org.jetbrains.kotlin.plugin.spring")
-        plugin("org.springframework.boot")
-        plugin("kotlin")
-        plugin("java-library")
-        plugin("kotlin-jpa")
-        plugin("io.spring.dependency-management")
-        plugin("kotlin-kapt")
-        plugin("application")
-        plugin("org.jlleitschuh.gradle.ktlint")
-    }
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "org.jetbrains.kotlin.plugin.spring")
+    apply(plugin = "org.springframework.boot")
+    apply(plugin = "kotlin")
+    apply(plugin = "java-library")
+    apply(plugin = "kotlin-jpa")
+    apply(plugin = "io.spring.dependency-management")
+    apply(plugin = "kotlin-kapt")
+    apply(plugin = "application")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     dependencies {
+        // for kotlin
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+        // for spring commons
         implementation("org.springframework.boot:spring-boot-autoconfigure")
         implementation("org.springframework.boot:spring-boot-starter-logging")
-        implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
-        implementation("ch.qos.logback:logback-classic")
-
+        // for test
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
@@ -66,6 +75,13 @@ subprojects {
 configure(allprojects.filter { it.name != "piikii-common" }) {
     dependencies {
         implementation(project(":piikii-common"))
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        cacheDynamicVersionsFor(10 * 60, TimeUnit.SECONDS)
+        cacheChangingModulesFor(4, TimeUnit.HOURS)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.parallel = true
+org.gradle.daemon = true
+org.gradle.caching = true
+org.gradle.configureondemand = true
+org.gradle.jvmargs = -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,19 +1,5 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
-}
-
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
-}
-
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-    }
 }
 
 rootProject.name = "piikii"


### PR DESCRIPTION
## 이슈

close #44 

## 변경 사항

- Build Actions 구문에 Gradle 의존성 캐싱 작업을 추가합니다.
- 로컬 내에서 build시 최적화할 수 있는 설정들을 추가합니다.

## 스크린샷

## 부연 설명

### 참고자료

[꽤 괜찮은 블로그](https://blog.asamaru.net/2015/09/29/android-gradle-builds-speed-up/)

#### build.gradle.kts
```kotlin
allprojects {
    group = "com.piikii"
    version = "0.0.1-SNAPSHOT"

    repositories {
        mavenCentral()
    }

    tasks.withType<JavaCompile>().configureEach {
        options.isIncremental = true --> 변경된 소스 파일만 재컴파일
        options.isFork = true --> 컴파일 프로세스를 포크하여 컴파일을 별도의 JVM 프로세스에서 실행함으로써 빌드 성능 향상
    }
}


// 아래 코드블럭은 아래 링크의 문서를 참고한 설정입니다.
// https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.ResolutionStrategy.html

configurations.all {
    resolutionStrategy {
        cacheDynamicVersionsFor(10 * 60, TimeUnit.SECONDS)
        cacheChangingModulesFor(4, TimeUnit.HOURS)
    }
}
```

#### gradle.properties

```kotlin
org.gradle.parallel=true --> Gradle 병렬 빌드 모드를 설정한다. 여러 프로젝트를 빌드 할 때 효과가 있다.
org.gradle.daemon=true --> 데몬 프로세스를 사용할지 여부 설정한다. true 설정시 gradle을 daemon 모드로 실행하여 빌드시 gradle을 다시 실행하는 시간을 줄여준다.
org.gradle.caching=true --> 빌드 캐싱을 활성화한다.
org.gradle.configureondemand=true --> 관련 프로젝트가 있다면 필요한 부분만 빌드 설정한다.
org.gradle.jvmargs=-Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 --> 실행시 JVM 인수로 메모리를 설정을 늘려 메모리 부족으로 인한 속도저하를 막는 것이 목적이다. 따라서 적절한 양의 메모리를 할당해 주면 된다.
```

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
