### PR TITLE
feat: Vote 마감일 설정 시, 패스워드 검증로직 추가

### DIFF
--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/room/Room.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/room/Room.kt
@@ -10,7 +10,7 @@ data class Room(
     val address: String,
     val meetDay: LocalDate,
     val thumbnailLink: String,
-    val password: Short,
+    val password: Password,
     val voteDeadline: LocalDateTime?,
     val roomId: UUID,
 ) {
@@ -18,3 +18,6 @@ data class Room(
         return this.voteDeadline == null || this.voteDeadline.isBefore(LocalDateTime.now())
     }
 }
+
+@JvmInline
+value class Password(val value: String)

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/room/Room.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/room/Room.kt
@@ -17,6 +17,10 @@ data class Room(
     fun isVoteUnavailable(): Boolean {
         return this.voteDeadline == null || this.voteDeadline.isBefore(LocalDateTime.now())
     }
+
+    fun isPasswordValid(password: Password): Boolean {
+        return this.password == password
+    }
 }
 
 @JvmInline

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/RoomUseCase.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/RoomUseCase.kt
@@ -1,5 +1,6 @@
 package com.piikii.application.port.input.room
 
+import com.piikii.application.domain.room.Password
 import com.piikii.application.port.input.room.dto.request.RoomSaveRequestForm
 import com.piikii.application.port.input.room.dto.request.RoomUpdateRequestForm
 import com.piikii.application.port.input.room.dto.response.RoomGetResponseForm
@@ -18,6 +19,7 @@ interface RoomUseCase {
 
     fun changeVoteDeadline(
         roomId: UUID,
+        password: Password,
         voteDeadline: LocalDateTime,
     )
 }

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/dto/request/RoomSaveRequestForm.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/dto/request/RoomSaveRequestForm.kt
@@ -1,8 +1,10 @@
 package com.piikii.application.port.input.room.dto.request
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.piikii.application.domain.room.Password
 import com.piikii.application.domain.room.Room
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.util.UUID
 
@@ -17,7 +19,8 @@ data class RoomSaveRequestForm(
     @Schema(description = "썸네일 이미지")
     val thumbnailLink: String,
     @Schema(description = "모임 비밀번호")
-    val password: Short,
+    @Size(max = 4, message = "Data must be 4 characters or less")
+    val password: Password,
     @Schema(description = "모임 날짜")
     val meetDay: LocalDate,
 ) {

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/dto/request/RoomUpdateRequestForm.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/dto/request/RoomUpdateRequestForm.kt
@@ -1,7 +1,9 @@
 package com.piikii.application.port.input.room.dto.request
 
+import com.piikii.application.domain.room.Password
 import com.piikii.application.domain.room.Room
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -16,7 +18,8 @@ data class RoomUpdateRequestForm(
     @Schema(description = "썸네일 이미지")
     val thumbnailLink: String,
     @Schema(description = "모임 비밀번호")
-    val password: Short,
+    @Size(max = 4, message = "Data must be 4 characters or less")
+    val password: Password,
     @Schema(description = "모임 날짜")
     val meetDay: LocalDate,
     @Schema(description = "투표 마감일")

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/dto/request/VoteDeadlineSetRequest.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/room/dto/request/VoteDeadlineSetRequest.kt
@@ -1,9 +1,14 @@
 package com.piikii.application.port.input.room.dto.request
 
+import com.piikii.application.domain.room.Password
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
 data class VoteDeadlineSetRequest(
     @Schema(description = "투표 마감일")
     val voteDeadline: LocalDateTime,
+    @Schema(description = "방 패스워드")
+    @Size(max = 4, message = "Data must be 4 characters or less")
+    val password: Password,
 )

--- a/piikii-common/src/main/kotlin/com/piikii/common/exception/ExceptionCode.kt
+++ b/piikii-common/src/main/kotlin/com/piikii/common/exception/ExceptionCode.kt
@@ -7,6 +7,7 @@ enum class ExceptionCode(
     // 400
     ILLEGAL_ARGUMENT_EXCEPTION(400, "요청 값이 올바르지 않습니다."),
     UNAUTHORIZED(401, "인증된 토큰으로부터의 요청이 아닙니다."),
+    ROOM_PASSWORD_INVALID(401, "방 패스워드가 틀립니다."),
     ACCESS_DENIED(403, "해당 리소스에 접근할 수 없습니다."),
     NOT_FOUNDED(404, "해당 리소스를 찾을 수 없습니다."),
     CONFLICT(409, "해당 리소스가 중복됩니다."),

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/advice/ExceptionAdvice.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/advice/ExceptionAdvice.kt
@@ -3,6 +3,7 @@ package com.piikii.input.http.advice
 import com.piikii.common.exception.PiikiiException
 import com.piikii.common.logutil.SystemLogger.logger
 import com.piikii.input.http.dto.response.ExceptionResponse
+import jakarta.validation.ConstraintDeclarationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -19,6 +20,22 @@ class ExceptionAdvice {
                 ExceptionResponse(
                     message = piikiiException.defaultMessage,
                     cause = piikiiException.detailMessage,
+                    timestamp = System.currentTimeMillis(),
+                ),
+            )
+    }
+
+    @ExceptionHandler(ConstraintDeclarationException::class)
+    fun handleConstraintDeclarationException(
+        exception: ConstraintDeclarationException,
+    ): ResponseEntity<ExceptionResponse> {
+        logger.error(exception) { "RequestBody Validation Failure" }
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ExceptionResponse(
+                    message = "요청 형식이 잘못됬습니다 (Request Validation Failure)",
+                    cause = exception.message,
                     timestamp = System.currentTimeMillis(),
                 ),
             )

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/RoomApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/RoomApi.kt
@@ -9,6 +9,7 @@ import com.piikii.input.http.docs.RoomApiDocs
 import com.piikii.input.http.dto.ResponseForm
 import com.piikii.input.http.dto.RoomMessage
 import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,7 +29,7 @@ class RoomApi(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     override fun generate(
-        @RequestBody request: RoomSaveRequestForm,
+        @Validated @RequestBody request: RoomSaveRequestForm,
     ): ResponseForm<RoomSaveResponseForm> {
         return ResponseForm(
             data = roomUseCase.generate(request),
@@ -39,7 +40,7 @@ class RoomApi(
     @ResponseStatus(HttpStatus.OK)
     @PutMapping
     override fun modifyInformation(
-        @RequestBody request: RoomUpdateRequestForm,
+        @Validated @RequestBody request: RoomUpdateRequestForm,
     ): ResponseForm<Unit> {
         roomUseCase.modify(request)
         return ResponseForm(

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/RoomApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/RoomApi.kt
@@ -8,6 +8,7 @@ import com.piikii.application.port.input.room.dto.response.RoomSaveResponseForm
 import com.piikii.input.http.docs.RoomApiDocs
 import com.piikii.input.http.dto.ResponseForm
 import com.piikii.input.http.dto.RoomMessage
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
+@Validated
 @RestController
 @RequestMapping("/v1/rooms")
 class RoomApi(
@@ -29,7 +31,7 @@ class RoomApi(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     override fun generate(
-        @Validated @RequestBody request: RoomSaveRequestForm,
+        @Valid @RequestBody request: RoomSaveRequestForm,
     ): ResponseForm<RoomSaveResponseForm> {
         return ResponseForm(
             data = roomUseCase.generate(request),
@@ -40,7 +42,7 @@ class RoomApi(
     @ResponseStatus(HttpStatus.OK)
     @PutMapping
     override fun modifyInformation(
-        @Validated @RequestBody request: RoomUpdateRequestForm,
+        @Valid @RequestBody request: RoomUpdateRequestForm,
     ): ResponseForm<Unit> {
         roomUseCase.modify(request)
         return ResponseForm(

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/VoteApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/VoteApi.kt
@@ -7,6 +7,7 @@ import com.piikii.input.http.docs.VoteApiDocs
 import com.piikii.input.http.dto.ResponseForm
 import com.piikii.input.http.dto.request.VoteRequest
 import com.piikii.input.http.dto.response.VoteStatusResponse
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
+@Validated
 @RestController
 @RequestMapping("/room/{roomId}/votes")
 class VoteApi(
@@ -29,7 +31,7 @@ class VoteApi(
     @PatchMapping("/deadline")
     override fun changeVoteDeadline(
         @PathVariable roomId: UUID,
-        @Validated @RequestBody request: VoteDeadlineSetRequest,
+        @Valid @RequestBody request: VoteDeadlineSetRequest,
     ): ResponseForm<Unit> {
         roomUseCase.changeVoteDeadline(roomId, request.password, request.voteDeadline)
         return ResponseForm.EMPTY_RESPONSE

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/VoteApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/VoteApi.kt
@@ -31,7 +31,7 @@ class VoteApi(
         @PathVariable roomId: UUID,
         @Validated @RequestBody request: VoteDeadlineSetRequest,
     ): ResponseForm<Unit> {
-        roomUseCase.changeVoteDeadline(roomId, request.voteDeadline)
+        roomUseCase.changeVoteDeadline(roomId, request.password, request.voteDeadline)
         return ResponseForm.EMPTY_RESPONSE
     }
 

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/VoteApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/VoteApi.kt
@@ -8,6 +8,7 @@ import com.piikii.input.http.dto.ResponseForm
 import com.piikii.input.http.dto.request.VoteRequest
 import com.piikii.input.http.dto.response.VoteStatusResponse
 import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,7 +29,7 @@ class VoteApi(
     @PatchMapping("/deadline")
     override fun changeVoteDeadline(
         @PathVariable roomId: UUID,
-        @RequestBody request: VoteDeadlineSetRequest,
+        @Validated @RequestBody request: VoteDeadlineSetRequest,
     ): ResponseForm<Unit> {
         roomUseCase.changeVoteDeadline(roomId, request.voteDeadline)
         return ResponseForm.EMPTY_RESPONSE

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/dto/response/ExceptionResponse.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/dto/response/ExceptionResponse.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class ExceptionResponse(
-    val message: String,
+    val message: String?,
     val cause: String?,
     val timestamp: Long,
 )

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/RoomEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/RoomEntity.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.persistence.postgresql.persistence.entity
 
+import com.piikii.application.domain.room.Password
 import com.piikii.application.domain.room.Room
 import com.piikii.output.persistence.postgresql.persistence.common.BaseEntity
 import jakarta.persistence.Column
@@ -22,8 +23,8 @@ class RoomEntity(
     var meetDay: LocalDate,
     @Column(name = "thumbnail_link", length = 255)
     var thumbnailLink: String,
-    @Column(name = "password", nullable = false)
-    var password: Short,
+    @Column(name = "password", nullable = false, length = 4)
+    var password: Password,
     @Column(name = "vote_deadline")
     var voteDeadline: LocalDateTime?,
     @Column(name = "room_id", nullable = false, unique = true)


### PR DESCRIPTION
## 이슈

#39 

## 변경 사항

- Vote 마감일 지정 시, 패스워드를 확인할 수 있도록 검증 로직을 추가했습니다.
- 패스워드는 숫자 4자리로 이를 위한 타입을 지정했습니다.
- 방 생성 시, 패스워드의 형식이 맞도록 Validation annotation을 추가했습니다.
- Validation 실패 시 적절한 오류를 확인할 수 있도록 Handling 코드를 추가했습니다.

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [ ] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
