### PR TITLE
fix: rename class/variables

### DIFF
--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/PlaceUseCase.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/PlaceUseCase.kt
@@ -14,7 +14,7 @@ interface PlaceUseCase {
         placeImages: List<MultipartFile>?,
     ): PlaceResponse
 
-    fun findAllByRoomUidGroupByPlaceType(targetRoomUid: UUID): List<ScheduleTypeGroupResponse>
+    fun findAllByRoomUidGroupByPlaceType(roomUid: UUID): List<ScheduleTypeGroupResponse>
 
     fun modify(
         targetRoomUid: UUID,

--- a/piikii-bootstrap/src/main/kotlin/com/piikii/bootstrap/PiikiiBootstrapApplication.kt
+++ b/piikii-bootstrap/src/main/kotlin/com/piikii/bootstrap/PiikiiBootstrapApplication.kt
@@ -1,11 +1,9 @@
 package com.piikii.bootstrap
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication(scanBasePackages = ["com.piikii"])
-@ConfigurationPropertiesScan("com.piikii.output.storage.ncp.config")
 class PiikiiBootstrapApplication
 
 fun main(args: Array<String>) {

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/adapter/RoomAdapter.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/adapter/RoomAdapter.kt
@@ -24,7 +24,7 @@ class RoomAdapter(
 
     @Transactional
     override fun update(room: Room) {
-        val foundRoom = findByroomUid(room.roomUid)
+        val foundRoom = findByRoomUid(room.roomUid)
         foundRoom.update(room)
     }
 
@@ -34,10 +34,10 @@ class RoomAdapter(
     }
 
     override fun findById(roomUid: UUID): Room {
-        return findByroomUid(roomUid).toDomain()
+        return findByRoomUid(roomUid).toDomain()
     }
 
-    private fun findByroomUid(roomUid: UUID): RoomEntity {
+    private fun findByRoomUid(roomUid: UUID): RoomEntity {
         return roomRepository.findByroomUid(roomUid)
             ?: throw PiikiiException(
                 exceptionCode = ExceptionCode.NOT_FOUNDED,

--- a/piikii-output-storage/ncp/src/main/kotlin/com/piikii/output/storage/ncp/config/NcpProperties.kt
+++ b/piikii-output-storage/ncp/src/main/kotlin/com/piikii/output/storage/ncp/config/NcpProperties.kt
@@ -1,6 +1,12 @@
 package com.piikii.output.storage.ncp.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(NcpProperties::class)
+class NcpConfig
 
 @ConfigurationProperties(prefix = "ncp")
 data class NcpProperties(


### PR DESCRIPTION
## 이슈

프로젝트에서 잘못 설정된 부분 몇개 수정했습니다.

## 변경 사항
- [fix: rename findByroomUid to findByRoomUid](https://github.com/mash-up-kr/piikii_Spring/commit/6fde0ee4f518da35489cc4c2a3d319cc76da3339)
- [fix: rename targetRoomUid to roomUid](https://github.com/mash-up-kr/piikii_Spring/commit/cfad70ef486d1da57d828a8e1408388ab25abdb7)
- [feat: use EnableConfigurationProperties instead of using ConfigurationPropertiesScan at bootstrap(https://github.com/mash-up-kr/piikii_Spring/commit/eecf7a8aa452d1a82bfc3ae27f2d839a7f86dc6f) 

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
