### PR TITLE
chore: label auto assign 항목을 세분화합니다.

### DIFF
--- a/.github/workflows/config/auto-assign-label-config.yml
+++ b/.github/workflows/config/auto-assign-label-config.yml
@@ -33,6 +33,14 @@ module-input-adapter:
   - changed-files:
       - any-glob-to-any-file: [ 'piikii-input-http/**' ]
 
-module-output-adapter:
+module-output-storage-services:
   - changed-files:
-      - any-glob-to-any-file: [ 'piikii-output-cache/**', 'piikii-output-eventbroker/**', 'piikii-output-persistence/**', 'piikii-output-storage/**']
+      - any-glob-to-any-file: [ 'piikii-output-cache/**', 'piikii-output-persistence/**', 'piikii-output-storage/**' ]
+
+module-output-event:
+  - changed-files:
+      - any-glob-to-any-file: [ 'piikii-output-eventbroker/**' ]
+
+module-output-web:
+  - changed-files:
+      - any-glob-to-any-file: [ 'piikii-output-web/**' ]


### PR DESCRIPTION
## 이슈

output adapter에 대한 label을 상세하게 세분화합니다.

## 변경 사항

```
module-output-storage-services:
  - changed-files:
      - any-glob-to-any-file: [ 'piikii-output-cache/**', 'piikii-output-persistence/**', 'piikii-output-storage/**' ]

module-output-event:
  - changed-files:
      - any-glob-to-any-file: [ 'piikii-output-eventbroker/**' ]

module-output-web:
  - changed-files:
      - any-glob-to-any-file: [ 'piikii-output-web/**' ]

```



