### PR TITLE
feat: 장소 입력자동화 정보 DB 저장

### DIFF
--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/generic/Origin.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/generic/Origin.kt
@@ -1,7 +1,7 @@
 package com.piikii.application.domain.generic
 
-enum class Origin {
-    AVOCADO,
-    LEMON,
-    MANUAL,
+enum class Origin(val prefix: String) {
+    AVOCADO("A"),
+    LEMON("L"),
+    MANUAL("M"),
 }

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
@@ -21,14 +21,17 @@ data class OriginPlace(
 
 @JvmInline
 value class OriginMapId(val value: String) {
-
     fun toId(): String {
         return value.split(SEPARATOR).last()
     }
 
     companion object {
         private const val SEPARATOR: String = "_"
-        fun of(id: Long, origin: Origin): OriginMapId {
+
+        fun of(
+            id: Long,
+            origin: Origin,
+        ): OriginMapId {
             return OriginMapId("${origin.prefix}$SEPARATOR$id")
         }
     }

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
@@ -20,4 +20,16 @@ data class OriginPlace(
 )
 
 @JvmInline
-value class OriginMapId(val value: Long)
+value class OriginMapId(val value: String) {
+
+    fun toId(): String {
+        return value.split(SEPARATOR).last()
+    }
+
+    companion object {
+        private const val SEPARATOR: String = "_"
+        fun of(id: Long, origin: Origin): OriginMapId {
+            return OriginMapId("${origin.prefix}$SEPARATOR$id")
+        }
+    }
+}

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
@@ -6,7 +6,7 @@ import com.piikii.application.domain.generic.ThumbnailLinks
 data class OriginPlace(
     val id: Long?,
     val name: String,
-    val originMapId: Long,
+    val originMapId: OriginMapId,
     val url: String,
     val thumbnailLinks: ThumbnailLinks,
     val address: String? = null,
@@ -18,3 +18,6 @@ data class OriginPlace(
     val category: String?,
     val origin: Origin,
 )
+
+@JvmInline
+value class OriginMapId(val value: Long)

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlaceService.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlaceService.kt
@@ -22,8 +22,8 @@ class OriginPlaceService(
                     ExceptionCode.NOT_SUPPORT_AUTO_COMPLETE_URL,
                     "No AutoComplete client found for $url",
                 )
-        val placeId = originPlaceAutoCompleteClient.extractPlaceId(plainUrl)
-        return originPlaceAutoCompleteClient.getAutoCompletedPlace(url = plainUrl, placeId = placeId)
+        val originMapId = originPlaceAutoCompleteClient.extractOriginMapId(plainUrl)
+        return originPlaceAutoCompleteClient.getAutoCompletedPlace(url = plainUrl, originMapId = originMapId)
     }
 
     private fun getUrlOfRemovedParameters(url: String): String {

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlaceService.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlaceService.kt
@@ -23,7 +23,9 @@ class OriginPlaceService(
                     "No AutoComplete client found for $url",
                 )
         val originMapId = originPlaceAutoCompleteClient.extractOriginMapId(plainUrl)
-        return originPlaceAutoCompleteClient.getAutoCompletedPlace(url = plainUrl, originMapId = originMapId)
+        return originPlaceQueryPort.findByOriginMapId(originMapId)
+            ?: originPlaceAutoCompleteClient.getAutoCompletedPlace(url = plainUrl, originMapId = originMapId)
+                .let { originPlaceCommandPort.save(it) }
     }
 
     private fun getUrlOfRemovedParameters(url: String): String {

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/PlaceRequest.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/PlaceRequest.kt
@@ -46,17 +46,6 @@ data class AddPlaceRequest(
     @field:Max(value = 5, message = "별점은 5 이하여야 합니다.")
     @field:Schema(description = "별점 (0-5)", example = "4.5")
     val starGrade: Float?,
-    @field:NotNull(message = "장소 정보 제공처")
-    @field:Schema(
-        description = "장소 정보 제공처",
-        allowableValues = [
-            "AVOCADO",
-            "LEMON",
-            "MANUAL",
-        ],
-        example = "MANUAL",
-    )
-    val origin: Origin,
     @field:NotBlank(message = "메모는 필수이며 빈 문자열이 허용되지 않습니다.")
     @field:Size(max = 50, message = "메모는 50자를 초과할 수 없습니다.")
     @field:Schema(description = "메모", example = "맛있는 레스토랑")
@@ -83,7 +72,7 @@ data class AddPlaceRequest(
             address = address,
             phoneNumber = phoneNumber,
             starGrade = starGrade,
-            origin = origin,
+            origin = Origin.MANUAL,
             memo = memo,
         )
     }
@@ -116,16 +105,6 @@ data class ModifyPlaceRequest(
     @field:Max(value = 5, message = "별점은 5 이하여야 합니다.")
     @field:Schema(description = "별점 (0-5)", example = "4.5")
     val starGrade: Float?,
-    @field:Schema(
-        description = "장소 정보 제공처",
-        allowableValues = [
-            "AVOCADO",
-            "LEMON",
-            "MANUAL",
-        ],
-        example = "MANUAL",
-    )
-    val origin: Origin,
     @field:NotBlank(message = "메모는 필수이며 빈 문자열이 허용되지 않습니다.")
     @field:Size(max = 50, message = "메모는 50자를 초과할 수 없습니다.")
     @field:Schema(description = "메모", example = "맛있는 레스토랑")
@@ -153,7 +132,7 @@ data class ModifyPlaceRequest(
             address = address,
             phoneNumber = phoneNumber,
             starGrade = starGrade,
-            origin = origin,
+            origin = Origin.MANUAL,
             memo = memo,
         )
     }

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/output/persistence/OriginPlacePort.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/output/persistence/OriginPlacePort.kt
@@ -1,20 +1,12 @@
 package com.piikii.application.port.output.persistence
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 
 interface OriginPlaceQueryPort {
-    fun retrieve(id: Long): OriginPlace
-
-    fun retrieveAll(ids: List<Long>): List<OriginPlace>
+    fun findByOriginMapId(originMapId: OriginMapId): OriginPlace?
 }
 
 interface OriginPlaceCommandPort {
     fun save(originPlace: OriginPlace): OriginPlace
-
-    fun update(
-        originPlace: OriginPlace,
-        id: Long,
-    )
-
-    fun delete(id: Long)
 }

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/output/web/OriginPlaceAutoCompleteClient.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/output/web/OriginPlaceAutoCompleteClient.kt
@@ -1,14 +1,15 @@
 package com.piikii.application.port.output.web
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 
 interface OriginPlaceAutoCompleteClient {
     fun isAutoCompleteSupportedUrl(url: String): Boolean
 
-    fun extractPlaceId(url: String): String
+    fun extractOriginMapId(url: String): OriginMapId
 
     fun getAutoCompletedPlace(
         url: String,
-        placeId: String,
+        originMapId: OriginMapId,
     ): OriginPlace
 }

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/adapter/OriginPlaceAdapter.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/adapter/OriginPlaceAdapter.kt
@@ -1,11 +1,11 @@
 package com.piikii.output.persistence.postgresql.adapter
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 import com.piikii.application.port.output.persistence.OriginPlaceCommandPort
 import com.piikii.application.port.output.persistence.OriginPlaceQueryPort
 import com.piikii.output.persistence.postgresql.persistence.entity.OriginPlaceEntity
 import com.piikii.output.persistence.postgresql.persistence.repository.OriginPlaceRepository
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
@@ -16,34 +16,11 @@ class OriginPlaceAdapter(
 ) : OriginPlaceCommandPort, OriginPlaceQueryPort {
     @Transactional
     override fun save(originPlace: OriginPlace): OriginPlace {
-        val entity = OriginPlaceEntity.from(originPlace)
-        originPlaceRepository.save(entity)
-        return entity.toDomain()
+        return originPlaceRepository.save(OriginPlaceEntity.from(originPlace))
+            .toDomain()
     }
 
-    @Transactional
-    override fun update(
-        originPlace: OriginPlace,
-        id: Long,
-    ) {
-        TODO("Not yet implemented")
-    }
-
-    @Transactional
-    override fun delete(id: Long) {
-        TODO("Not yet implemented")
-    }
-
-    override fun retrieve(id: Long): OriginPlace {
-        val originPlaceEntity = originPlaceRepository.findById(id)
-        if (originPlaceEntity.isPresent) {
-            return originPlaceEntity.get().toDomain()
-        }
-        // TODO 예외 정의
-        throw EntityNotFoundException()
-    }
-
-    override fun retrieveAll(ids: List<Long>): List<OriginPlace> {
-        TODO("Not yet implemented")
+    override fun findByOriginMapId(originMapId: OriginMapId): OriginPlace? {
+        return originPlaceRepository.findByOriginMapId(originMapId)?.toDomain()
     }
 }

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -27,8 +26,7 @@ class OriginPlaceEntity(
     var name: String,
     @Column(name = "url", nullable = false, length = 255)
     val url: String,
-    @Column(name = "thumbnail_links")
-    @Lob
+    @Column(name = "thumbnail_links", columnDefinition = "TEXT")
     val thumbnailLinks: String,
     @Column(name = "address", length = 255)
     val address: String? = null,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -26,7 +27,8 @@ class OriginPlaceEntity(
     var name: String,
     @Column(name = "url", nullable = false, length = 255)
     val url: String,
-    @Column(name = "thumbnail_links", nullable = false, length = 255)
+    @Column(name = "thumbnail_links")
+    @Lob
     val thumbnailLinks: String,
     @Column(name = "address", length = 255)
     val address: String? = null,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
@@ -20,7 +20,7 @@ import org.hibernate.annotations.SQLRestriction
 @SQLDelete(sql = "UPDATE piikii.origin_place SET is_deleted = true WHERE id = ?")
 @DynamicUpdate
 class OriginPlaceEntity(
-    @Column(name = "origin_map_id", nullable = false)
+    @Column(name = "origin_map_id", nullable = false, unique = true)
     val originMapId: OriginMapId,
     @Column(name = "name", length = 255, nullable = false)
     var name: String,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
@@ -2,6 +2,7 @@ package com.piikii.output.persistence.postgresql.persistence.entity
 
 import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.generic.ThumbnailLinks
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 import com.piikii.output.persistence.postgresql.persistence.common.BaseEntity
 import jakarta.persistence.Column
@@ -20,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction
 @DynamicUpdate
 class OriginPlaceEntity(
     @Column(name = "origin_map_id", nullable = false)
-    val originMapId: Long,
+    val originMapId: OriginMapId,
     @Column(name = "name", length = 255, nullable = false)
     var name: String,
     @Column(name = "url", nullable = false, length = 255)

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -29,8 +28,7 @@ class PlaceEntity(
     var name: String,
     @Column(name = "url", length = 255)
     var url: String?,
-    @Column(name = "thumbnail_links")
-    @Lob
+    @Column(name = "thumbnail_links", columnDefinition = "TEXT")
     var thumbnailLinks: String?,
     @Column(name = "address", length = 255)
     var address: String?,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -28,7 +29,8 @@ class PlaceEntity(
     var name: String,
     @Column(name = "url", length = 255)
     var url: String?,
-    @Column(name = "thumbnail_links", length = 255, nullable = false)
+    @Column(name = "thumbnail_links")
+    @Lob
     var thumbnailLinks: String?,
     @Column(name = "address", length = 255)
     var address: String?,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/repository/OriginPlaceRepository.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/repository/OriginPlaceRepository.kt
@@ -1,6 +1,9 @@
 package com.piikii.output.persistence.postgresql.persistence.repository
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.persistence.postgresql.persistence.entity.OriginPlaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface OriginPlaceRepository : JpaRepository<OriginPlaceEntity, Long>
+interface OriginPlaceRepository : JpaRepository<OriginPlaceEntity, Long> {
+    fun findByOriginMapId(originMapId: OriginMapId): OriginPlaceEntity?
+}

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceAutoCompleteClient.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceAutoCompleteClient.kt
@@ -5,22 +5,22 @@ import com.piikii.application.domain.place.OriginPlace
 import com.piikii.application.port.output.web.OriginPlaceAutoCompleteClient
 import com.piikii.common.exception.ExceptionCode
 import com.piikii.common.exception.PiikiiException
-import com.piikii.output.web.avocado.parser.AvocadoPlaceIdParserStrategy
+import com.piikii.output.web.avocado.parser.AvocadoOriginMapIdParserStrategy
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 
 @Component
 class AvocadoPlaceAutoCompleteClient(
-    private val avocadoPlaceIdParserStrategy: AvocadoPlaceIdParserStrategy,
+    private val avocadoOriginMapIdParserStrategy: AvocadoOriginMapIdParserStrategy,
     private val avocadoApiClient: RestClient,
 ) : OriginPlaceAutoCompleteClient {
     override fun isAutoCompleteSupportedUrl(url: String): Boolean {
-        return avocadoPlaceIdParserStrategy.getParserBySupportedUrl(url) != null
+        return avocadoOriginMapIdParserStrategy.getParserBySupportedUrl(url) != null
     }
 
     override fun extractOriginMapId(url: String): OriginMapId {
-        return avocadoPlaceIdParserStrategy.getParserBySupportedUrl(url)?.parseOriginMapId(url)
+        return avocadoOriginMapIdParserStrategy.getParserBySupportedUrl(url)?.parseOriginMapId(url)
             ?: throw PiikiiException(ExceptionCode.NOT_SUPPORT_AUTO_COMPLETE_URL)
     }
 

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceAutoCompleteClient.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceAutoCompleteClient.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.avocado.adapter
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 import com.piikii.application.port.output.web.OriginPlaceAutoCompleteClient
 import com.piikii.common.exception.ExceptionCode
@@ -18,17 +19,17 @@ class AvocadoPlaceAutoCompleteClient(
         return avocadoPlaceIdParserStrategy.getParserBySupportedUrl(url) != null
     }
 
-    override fun extractPlaceId(url: String): String {
-        return avocadoPlaceIdParserStrategy.getParserBySupportedUrl(url)?.parsePlaceId(url)
+    override fun extractOriginMapId(url: String): OriginMapId {
+        return avocadoPlaceIdParserStrategy.getParserBySupportedUrl(url)?.parseOriginMapId(url)
             ?: throw PiikiiException(ExceptionCode.NOT_SUPPORT_AUTO_COMPLETE_URL)
     }
 
     override fun getAutoCompletedPlace(
         url: String,
-        placeId: String,
+        originMapId: OriginMapId,
     ): OriginPlace {
         return avocadoApiClient.get()
-            .uri("/$placeId")
+            .uri("/${originMapId.value}")
             .retrieve()
             .body<AvocadoPlaceInfoResponse>()
             ?.toOriginPlace(url)

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceAutoCompleteClient.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceAutoCompleteClient.kt
@@ -29,7 +29,7 @@ class AvocadoPlaceAutoCompleteClient(
         originMapId: OriginMapId,
     ): OriginPlace {
         return avocadoApiClient.get()
-            .uri("/${originMapId.value}")
+            .uri("/${originMapId.toId()}")
             .retrieve()
             .body<AvocadoPlaceInfoResponse>()
             ?.toOriginPlace(url)

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceInfoResponse.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceInfoResponse.kt
@@ -28,7 +28,7 @@ data class AvocadoPlaceInfoResponse(
     fun toOriginPlace(url: String): OriginPlace {
         return OriginPlace(
             id = null,
-            originMapId = OriginMapId(id),
+            originMapId = OriginMapId.of(id = id, origin = Origin.AVOCADO),
             name = name,
             url = url,
             thumbnailLinks = ThumbnailLinks(images ?: emptyList()),

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceInfoResponse.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/adapter/AvocadoPlaceInfoResponse.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.generic.ThumbnailLinks
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -27,7 +28,7 @@ data class AvocadoPlaceInfoResponse(
     fun toOriginPlace(url: String): OriginPlace {
         return OriginPlace(
             id = null,
-            originMapId = id,
+            originMapId = OriginMapId(id),
             name = name,
             url = url,
             thumbnailLinks = ThumbnailLinks(images ?: emptyList()),

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/config/AvocadoConfig.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/config/AvocadoConfig.kt
@@ -54,6 +54,7 @@ data class AvocadoUrl(
 ) {
     data class Regex(
         val web: String,
+        val mobileWeb: String,
         val share: String,
     )
 }

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
@@ -2,6 +2,7 @@ package com.piikii.output.web.avocado.parser
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.config.AvocadoProperties
+import com.piikii.output.web.avocado.parser.AvocadoOriginMapIdParser.Companion.ORIGIN_MAP_IP_REGEX
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 
@@ -29,23 +30,36 @@ interface AvocadoOriginMapIdParser {
             ?.toLongOrNull()
             ?.let { OriginMapId(it) }
     }
+
+    companion object {
+        const val ORIGIN_MAP_IP_REGEX = "\\d+"
+    }
 }
 
 @Component
 class MapUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
-    private val patternRegex: Regex = "${properties.url.regex.web}$PLACE_ID_REGEX".toRegex()
-    private val parseRegex: Regex = "${properties.url.regex.web}($PLACE_ID_REGEX)".toRegex()
+    private val regex: Regex = "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex()
 
     override fun pattern(): Regex {
-        return patternRegex
+        return regex
     }
 
     override fun parseOriginMapId(url: String): OriginMapId? {
-        return parseRegex.find(url).parseFromMatchResult()
+        return regex.find(url).parseFromMatchResult()
     }
 
-    companion object {
-        const val PLACE_ID_REGEX = "\\d+"
+}
+
+@Component
+class MapMobileUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
+    private val regex: Regex = "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)/home".toRegex()
+
+    override fun pattern(): Regex {
+        return regex
+    }
+
+    override fun parseOriginMapId(url: String): OriginMapId? {
+        return regex.find(url).parseFromMatchResult()
     }
 }
 

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
@@ -38,10 +38,11 @@ interface AvocadoOriginMapIdParser {
 
 @Component
 class MapUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
-    private val regexes: List<Regex> = listOf(
-        "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
-        "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)/home".toRegex(),
-    )
+    private val regexes: List<Regex> =
+        listOf(
+            "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+            "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)/home".toRegex(),
+        )
 
     override fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? =
         takeIf { regexes.any { regex -> regex.matches(url) } }
@@ -59,8 +60,7 @@ class ShareUrlIdParser(
     private val idParameterRegex: Regex = "id=(\\d+)".toRegex()
     private val client: RestClient = RestClient.builder().build()
 
-    override fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? =
-        takeIf { regex.matches(url) }
+    override fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? = takeIf { regex.matches(url) }
 
     override fun parseOriginMapId(url: String): OriginMapId? {
         val response =

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.avocado.parser
 
+import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.config.AvocadoProperties
 import org.springframework.stereotype.Component
@@ -27,7 +28,7 @@ interface AvocadoOriginMapIdParser {
         return this?.groupValues
             ?.getOrNull(1)
             ?.toLongOrNull()
-            ?.let { OriginMapId(it) }
+            ?.let { OriginMapId.of(id = it, origin = Origin.AVOCADO) }
     }
 }
 

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
@@ -6,13 +6,13 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 
 @Component
-class AvocadoPlaceIdParserStrategy(private val parsers: List<AvocadoPlaceIdParser>) {
-    fun getParserBySupportedUrl(url: String): AvocadoPlaceIdParser? {
+class AvocadoOriginMapIdParserStrategy(private val parsers: List<AvocadoOriginMapIdParser>) {
+    fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? {
         return parsers.find { it.pattern().matches(url) }
     }
 }
 
-interface AvocadoPlaceIdParser {
+interface AvocadoOriginMapIdParser {
     fun pattern(): Regex
 
     fun parseOriginMapId(url: String): OriginMapId?
@@ -32,7 +32,7 @@ interface AvocadoPlaceIdParser {
 }
 
 @Component
-class MapPlaceIdParser(properties: AvocadoProperties) : AvocadoPlaceIdParser {
+class MapUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
     private val patternRegex: Regex = "${properties.url.regex.web}$PLACE_ID_REGEX".toRegex()
     private val parseRegex: Regex = "${properties.url.regex.web}($PLACE_ID_REGEX)".toRegex()
 
@@ -50,9 +50,9 @@ class MapPlaceIdParser(properties: AvocadoProperties) : AvocadoPlaceIdParser {
 }
 
 @Component
-class SharePlaceIdParser(
+class ShareUrlIdParser(
     properties: AvocadoProperties,
-) : AvocadoPlaceIdParser {
+) : AvocadoOriginMapIdParser {
     private val regex: Regex = properties.url.regex.share.toRegex()
     private val idParameterRegex: Regex = "id=(\\d+)".toRegex()
     private val client: RestClient = RestClient.builder().build()

--- a/piikii-output-web/avocado/src/main/resources/avocado-config/application.yml
+++ b/piikii-output-web/avocado/src/main/resources/avocado-config/application.yml
@@ -5,6 +5,7 @@ avocado:
   url:
     regex:
       web: ${AVOCADO_WEB_URL_REGEX}
+      mobile-web: ${AVOCADO_MOBILE_WEB_URL_REGEX}
       share: ${AVOCADO_SHARE_URL_REGEX}
     api: ${AVOCADO_API_URL}
     referer: ${AVOCADO_REFERER_URL}

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.avocado
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
 import com.piikii.output.web.avocado.parser.MapPlaceIdParser
 import com.piikii.output.web.avocado.parser.SharePlaceIdParser
@@ -29,7 +30,7 @@ class AvocadoPlaceAutoCompleteClientTest {
     fun sharePlaceIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val parse = sharePlaceIdParser.parsePlaceId(url)
+        val parse = sharePlaceIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 
@@ -40,16 +41,16 @@ class AvocadoPlaceAutoCompleteClientTest {
         val pattern = mapPlaceIdParser.pattern()
         assertThat(pattern.matches(url)).isTrue()
 
-        val parse = mapPlaceIdParser.parsePlaceId(url)
+        val parse = mapPlaceIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 
     @Test
     fun getAutoCompletedPlaceTest() {
         val url = "주소를 입력하세요"
-        val id = "id를 입력하세요"
+        val id = 123L
 
-        val originPlace = avocadoPlaceAutoCompleteClient.getAutoCompletedPlace(url, id)
+        val originPlace = avocadoPlaceAutoCompleteClient.getAutoCompletedPlace(url, OriginMapId(id))
         println("originPlace = $originPlace")
     }
 }

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -2,6 +2,7 @@ package com.piikii.output.web.avocado
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
+import com.piikii.output.web.avocado.parser.MapMobileUrlIdParser
 import com.piikii.output.web.avocado.parser.MapUrlIdParser
 import com.piikii.output.web.avocado.parser.ShareUrlIdParser
 import org.assertj.core.api.Assertions.assertThat
@@ -18,30 +19,44 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(classes = [TestConfiguration::class])
 class AvocadoPlaceAutoCompleteClientTest {
     @Autowired
-    lateinit var sharePlaceIdParser: ShareUrlIdParser
+    lateinit var shareUrlIdParser: ShareUrlIdParser
 
     @Autowired
-    lateinit var mapPlaceIdParser: MapUrlIdParser
+    lateinit var mapUrlIdParser: MapUrlIdParser
+
+    @Autowired
+    lateinit var mapMobileUrlIdParser: MapMobileUrlIdParser
 
     @Autowired
     lateinit var avocadoPlaceAutoCompleteClient: AvocadoPlaceAutoCompleteClient
 
     @Test
-    fun sharePlaceIdParserTest() {
+    fun shareUrlIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val parse = sharePlaceIdParser.parseOriginMapId(url)
+        val parse = shareUrlIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 
     @Test
-    fun mapPlaceIdParserTest() {
+    fun mapUrlIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val pattern = mapPlaceIdParser.pattern()
+        val pattern = mapUrlIdParser.pattern()
         assertThat(pattern.matches(url)).isTrue()
 
-        val parse = mapPlaceIdParser.parseOriginMapId(url)
+        val parse = mapUrlIdParser.parseOriginMapId(url)
+        println("parse = $parse")
+    }
+
+    @Test
+    fun mapMobileUrlIdParserTest() {
+        val url = "주소를 입력하세요"
+
+        val pattern = mapMobileUrlIdParser.pattern()
+        assertThat(pattern.matches(url)).isTrue()
+
+        val parse = mapMobileUrlIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.avocado
 
+import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
 import com.piikii.output.web.avocado.parser.MapUrlIdParser
@@ -50,7 +51,7 @@ class AvocadoPlaceAutoCompleteClientTest {
         val url = "주소를 입력하세요"
         val id = 123L
 
-        val originPlace = avocadoPlaceAutoCompleteClient.getAutoCompletedPlace(url, OriginMapId(id))
+        val originPlace = avocadoPlaceAutoCompleteClient.getAutoCompletedPlace(url, OriginMapId.of(id, Origin.AVOCADO))
         println("originPlace = $originPlace")
     }
 }

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -2,8 +2,8 @@ package com.piikii.output.web.avocado
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
-import com.piikii.output.web.avocado.parser.MapPlaceIdParser
-import com.piikii.output.web.avocado.parser.SharePlaceIdParser
+import com.piikii.output.web.avocado.parser.MapUrlIdParser
+import com.piikii.output.web.avocado.parser.ShareUrlIdParser
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -18,10 +18,10 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(classes = [TestConfiguration::class])
 class AvocadoPlaceAutoCompleteClientTest {
     @Autowired
-    lateinit var sharePlaceIdParser: SharePlaceIdParser
+    lateinit var sharePlaceIdParser: ShareUrlIdParser
 
     @Autowired
-    lateinit var mapPlaceIdParser: MapPlaceIdParser
+    lateinit var mapPlaceIdParser: MapUrlIdParser
 
     @Autowired
     lateinit var avocadoPlaceAutoCompleteClient: AvocadoPlaceAutoCompleteClient

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -2,7 +2,6 @@ package com.piikii.output.web.avocado
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
-import com.piikii.output.web.avocado.parser.MapMobileUrlIdParser
 import com.piikii.output.web.avocado.parser.MapUrlIdParser
 import com.piikii.output.web.avocado.parser.ShareUrlIdParser
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +24,7 @@ class AvocadoPlaceAutoCompleteClientTest {
     lateinit var mapUrlIdParser: MapUrlIdParser
 
     @Autowired
-    lateinit var mapMobileUrlIdParser: MapMobileUrlIdParser
+    lateinit var mapMobileUrlIdParser: MapUrlIdParser
 
     @Autowired
     lateinit var avocadoPlaceAutoCompleteClient: AvocadoPlaceAutoCompleteClient
@@ -42,21 +41,10 @@ class AvocadoPlaceAutoCompleteClientTest {
     fun mapUrlIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val pattern = mapUrlIdParser.pattern()
-        assertThat(pattern.matches(url)).isTrue()
+        val pattern = mapUrlIdParser.getParserBySupportedUrl(url)
+        assertThat(pattern).isNotNull()
 
         val parse = mapUrlIdParser.parseOriginMapId(url)
-        println("parse = $parse")
-    }
-
-    @Test
-    fun mapMobileUrlIdParserTest() {
-        val url = "주소를 입력하세요"
-
-        val pattern = mapMobileUrlIdParser.pattern()
-        assertThat(pattern.matches(url)).isTrue()
-
-        val parse = mapMobileUrlIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 

--- a/piikii-output-web/avocado/src/test/resources/application-test.yml
+++ b/piikii-output-web/avocado/src/test/resources/application-test.yml
@@ -5,6 +5,7 @@ avocado:
   url:
     regex:
       web: ${AVOCADO_WEB_URL_REGEX}
+      mobile-web: ${AVOCADO_MOBILE_WEB_URL_REGEX}
       share: ${AVOCADO_SHARE_URL_REGEX}
     api: ${AVOCADO_API_URL}
     referer: ${AVOCADO_REFERER_URL}

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceAutoCompleteClient.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceAutoCompleteClient.kt
@@ -29,7 +29,7 @@ class LemonPlaceAutoCompleteClient(
         originMapId: OriginMapId,
     ): OriginPlace {
         return lemonApiClient.get()
-            .uri("/${originMapId.value}")
+            .uri("/${originMapId.toId()}")
             .retrieve()
             .body<LemonPlaceInfoResponse>()
             ?.toOriginPlace(url)

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceAutoCompleteClient.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceAutoCompleteClient.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.lemon.adapter
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 import com.piikii.application.port.output.web.OriginPlaceAutoCompleteClient
 import com.piikii.common.exception.ExceptionCode
@@ -18,17 +19,17 @@ class LemonPlaceAutoCompleteClient(
         return lemonPlaceIdParser.isAutoCompleteSupportedUrl(url)
     }
 
-    override fun extractPlaceId(url: String): String {
-        return lemonPlaceIdParser.parse(url)
+    override fun extractOriginMapId(url: String): OriginMapId {
+        return lemonPlaceIdParser.parseOriginMapId(url)
             ?: throw PiikiiException(ExceptionCode.NOT_SUPPORT_AUTO_COMPLETE_URL)
     }
 
     override fun getAutoCompletedPlace(
         url: String,
-        placeId: String,
+        originMapId: OriginMapId,
     ): OriginPlace {
         return lemonApiClient.get()
-            .uri("/$placeId")
+            .uri("/${originMapId.value}")
             .retrieve()
             .body<LemonPlaceInfoResponse>()
             ?.toOriginPlace(url)

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceAutoCompleteClient.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceAutoCompleteClient.kt
@@ -5,22 +5,22 @@ import com.piikii.application.domain.place.OriginPlace
 import com.piikii.application.port.output.web.OriginPlaceAutoCompleteClient
 import com.piikii.common.exception.ExceptionCode
 import com.piikii.common.exception.PiikiiException
-import com.piikii.output.web.lemon.parser.LemonPlaceIdParser
+import com.piikii.output.web.lemon.parser.LemonOriginMapIdParser
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 
 @Component
 class LemonPlaceAutoCompleteClient(
-    private val lemonPlaceIdParser: LemonPlaceIdParser,
+    private val lemonOriginMapIdParser: LemonOriginMapIdParser,
     private val lemonApiClient: RestClient,
 ) : OriginPlaceAutoCompleteClient {
     override fun isAutoCompleteSupportedUrl(url: String): Boolean {
-        return lemonPlaceIdParser.isAutoCompleteSupportedUrl(url)
+        return lemonOriginMapIdParser.isAutoCompleteSupportedUrl(url)
     }
 
     override fun extractOriginMapId(url: String): OriginMapId {
-        return lemonPlaceIdParser.parseOriginMapId(url)
+        return lemonOriginMapIdParser.parseOriginMapId(url)
             ?: throw PiikiiException(ExceptionCode.NOT_SUPPORT_AUTO_COMPLETE_URL)
     }
 

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.generic.ThumbnailLinks
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.application.domain.place.OriginPlace
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -20,7 +21,7 @@ data class LemonPlaceInfoResponse(
         return OriginPlace(
             id = null,
             name = basicInfo.name,
-            originMapId = basicInfo.cid,
+            originMapId = OriginMapId(basicInfo.cid),
             url = url,
             thumbnailLinks = ThumbnailLinks(basicInfo.mainPhotoUrl),
             address = fullAddress,

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
@@ -21,7 +21,7 @@ data class LemonPlaceInfoResponse(
         return OriginPlace(
             id = null,
             name = basicInfo.name,
-            originMapId = OriginMapId(basicInfo.cid),
+            originMapId = OriginMapId.of(id = basicInfo.cid, origin = Origin.LEMON),
             url = url,
             thumbnailLinks = ThumbnailLinks(basicInfo.mainPhotoUrl),
             address = fullAddress,

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
@@ -12,7 +12,7 @@ data class LemonPlaceInfoResponse(
     val isMapUser: String?,
     val isExist: Boolean?,
     val basicInfo: BasicInfo,
-    val comment: Comment,
+    val comment: Comment?,
     val menuInfo: MenuInfo,
     val photo: Photo,
 ) {
@@ -43,7 +43,7 @@ data class LemonPlaceInfoResponse(
         @JsonProperty("mainphotourl")
         val mainPhotoUrl: String,
         @JsonProperty("phonenum")
-        val phoneNumber: String,
+        val phoneNumber: String?,
         val address: Address,
         val homepage: String?,
         val category: Category,

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/config/LemonConfig.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/config/LemonConfig.kt
@@ -28,5 +28,6 @@ data class LemonUrl(
 ) {
     data class Regex(
         val web: String,
+        val mobileWeb: String,
     )
 }

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -8,10 +8,11 @@ import org.springframework.stereotype.Component
 class LemonOriginMapIdParser(
     properties: LemonProperties,
 ) {
-    private val regexes: List<Regex> = listOf(
-        "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
-        "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex()
-    )
+    private val regexes: List<Regex> =
+        listOf(
+            "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+            "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+        )
 
     fun isAutoCompleteSupportedUrl(url: String): Boolean = regexes.any { it.matches(url) }
 

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -13,9 +13,7 @@ class LemonOriginMapIdParser(
         "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex()
     )
 
-    fun isAutoCompleteSupportedUrl(url: String): Boolean {
-        return regexes.any { it.matches(url) }
-    }
+    fun isAutoCompleteSupportedUrl(url: String): Boolean = regexes.any { it.matches(url) }
 
     fun parseOriginMapId(url: String): OriginMapId? {
         return regexes.firstOrNull { it.matches(url) }

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.lemon.parser
 
+import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.lemon.config.LemonProperties
 import org.springframework.stereotype.Component
@@ -23,7 +24,7 @@ class LemonOriginMapIdParser(
             ?.groupValues
             ?.getOrNull(1)
             ?.toLongOrNull()
-            ?.let { OriginMapId(it) }
+            ?.let { OriginMapId.of(id = it, origin = Origin.LEMON) }
     }
 
     companion object {

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -5,7 +5,7 @@ import com.piikii.output.web.lemon.config.LemonProperties
 import org.springframework.stereotype.Component
 
 @Component
-class LemonPlaceIdParser(
+class LemonOriginMapIdParser(
     properties: LemonProperties,
 ) {
     private val patternRegex: Regex = "${properties.url.regex.web}$PLACE_ID_REGEX".toRegex()

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -8,18 +8,18 @@ import org.springframework.stereotype.Component
 class LemonOriginMapIdParser(
     properties: LemonProperties,
 ) {
-    private val patternRegex: Regex = "${properties.url.regex.web}$PLACE_ID_REGEX".toRegex()
-    private val parseRegex: Regex = "${properties.url.regex.web}($PLACE_ID_REGEX)".toRegex()
+    private val regexes: List<Regex> = listOf(
+        "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+        "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex()
+    )
 
     fun isAutoCompleteSupportedUrl(url: String): Boolean {
-        return patternRegex.matches(url)
+        return regexes.any { it.matches(url) }
     }
 
     fun parseOriginMapId(url: String): OriginMapId? {
-        if (!isAutoCompleteSupportedUrl(url)) {
-            return null
-        }
-        return parseRegex.find(url)
+        return regexes.firstOrNull { it.matches(url) }
+            ?.find(url)
             ?.groupValues
             ?.getOrNull(1)
             ?.toLongOrNull()
@@ -27,6 +27,6 @@ class LemonOriginMapIdParser(
     }
 
     companion object {
-        const val PLACE_ID_REGEX = "\\d+"
+        const val ORIGIN_MAP_IP_REGEX = "\\d+"
     }
 }

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonPlaceIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonPlaceIdParser.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.lemon.parser
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.lemon.config.LemonProperties
 import org.springframework.stereotype.Component
 
@@ -14,11 +15,15 @@ class LemonPlaceIdParser(
         return patternRegex.matches(url)
     }
 
-    fun parse(url: String): String? {
+    fun parseOriginMapId(url: String): OriginMapId? {
         if (!isAutoCompleteSupportedUrl(url)) {
             return null
         }
-        return parseRegex.find(url)?.groupValues?.get(1)
+        return parseRegex.find(url)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toLongOrNull()
+            ?.let { OriginMapId(it) }
     }
 
     companion object {

--- a/piikii-output-web/lemon/src/main/resources/lemon-config/application.yml
+++ b/piikii-output-web/lemon/src/main/resources/lemon-config/application.yml
@@ -2,4 +2,5 @@ lemon:
   url:
     regex:
       web: ${LEMON_WEB_URL_REGEX}
+      mobile-web: ${LEMON_MOBILE_WEB_URL_REGEX}
     api: ${LEMON_API_URL}

--- a/piikii-output-web/lemon/src/test/kotlin/com/piikii/output/web/lemon/LemonPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/lemon/src/test/kotlin/com/piikii/output/web/lemon/LemonPlaceAutoCompleteClientTest.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.lemon
 
+import com.piikii.application.domain.generic.Origin
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.lemon.adapter.LemonPlaceAutoCompleteClient
 import org.assertj.core.api.Assertions.assertThat
@@ -30,7 +31,7 @@ class LemonPlaceAutoCompleteClientTest {
         val url = "URL을 입력해주세요"
         val id = 123L
 
-        val originPlace = lemonPlaceAutoCompleteClient.getAutoCompletedPlace(url, OriginMapId(id))
+        val originPlace = lemonPlaceAutoCompleteClient.getAutoCompletedPlace(url, OriginMapId.of(id, Origin.LEMON))
         println("originPlace = $originPlace")
     }
 }

--- a/piikii-output-web/lemon/src/test/kotlin/com/piikii/output/web/lemon/LemonPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/lemon/src/test/kotlin/com/piikii/output/web/lemon/LemonPlaceAutoCompleteClientTest.kt
@@ -1,5 +1,6 @@
 package com.piikii.output.web.lemon
 
+import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.lemon.adapter.LemonPlaceAutoCompleteClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
@@ -27,9 +28,9 @@ class LemonPlaceAutoCompleteClientTest {
     @Test
     fun getAutoCompletedPlaceTest() {
         val url = "URL을 입력해주세요"
-        val id = "id를 입력해주세요"
+        val id = 123L
 
-        val originPlace = lemonPlaceAutoCompleteClient.getAutoCompletedPlace(url, id)
+        val originPlace = lemonPlaceAutoCompleteClient.getAutoCompletedPlace(url, OriginMapId(id))
         println("originPlace = $originPlace")
     }
 }

--- a/piikii-output-web/lemon/src/test/resources/application-test.yml
+++ b/piikii-output-web/lemon/src/test/resources/application-test.yml
@@ -2,4 +2,5 @@ lemon:
   url:
     regex:
       web: ${LEMON_WEB_URL_REGEX}
+      mobile-web: ${LEMON_MOBILE_WEB_URL_REGEX}
     api: ${LEMON_API_URL}


### PR DESCRIPTION
## 이슈

#95 

## 변경 사항

장소입력 자동화 시, Origin Map Id를 이용해 DB에 미리 저장되어있는지 확인하고, 있으면 요청하지 않고 바로 활용할 수 있도록 구현
- OriginMapId value class를 통해 다른 DB ID와 헷갈리지 않게 구성함


데이터 갱신 주기는 #109 에서 고민 예정


## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
