### PR TITLE
feat: 장소입력 자동화 - 모바일 주소 패턴 지원

### DIFF
--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -27,8 +26,7 @@ class OriginPlaceEntity(
     var name: String,
     @Column(name = "url", nullable = false, length = 255)
     val url: String,
-    @Column(name = "thumbnail_links")
-    @Lob
+    @Column(name = "thumbnail_links", columnDefinition = "TEXT")
     val thumbnailLinks: String,
     @Column(name = "address", length = 255)
     val address: String? = null,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/OriginPlaceEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -26,7 +27,8 @@ class OriginPlaceEntity(
     var name: String,
     @Column(name = "url", nullable = false, length = 255)
     val url: String,
-    @Column(name = "thumbnail_links", nullable = false, length = 255)
+    @Column(name = "thumbnail_links")
+    @Lob
     val thumbnailLinks: String,
     @Column(name = "address", length = 255)
     val address: String? = null,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -29,8 +28,7 @@ class PlaceEntity(
     var name: String,
     @Column(name = "url", length = 255)
     var url: String?,
-    @Column(name = "thumbnail_links")
-    @Lob
+    @Column(name = "thumbnail_links", columnDefinition = "TEXT")
     var thumbnailLinks: String?,
     @Column(name = "address", length = 255)
     var address: String?,

--- a/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
+++ b/piikii-output-persistence/postgresql/src/main/kotlin/com/piikii/output/persistence/postgresql/persistence/entity/PlaceEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
@@ -28,7 +29,8 @@ class PlaceEntity(
     var name: String,
     @Column(name = "url", length = 255)
     var url: String?,
-    @Column(name = "thumbnail_links", length = 255, nullable = false)
+    @Column(name = "thumbnail_links")
+    @Lob
     var thumbnailLinks: String?,
     @Column(name = "address", length = 255)
     var address: String?,

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/config/AvocadoConfig.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/config/AvocadoConfig.kt
@@ -54,6 +54,7 @@ data class AvocadoUrl(
 ) {
     data class Regex(
         val web: String,
+        val mobileWeb: String,
         val share: String,
     )
 }

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
@@ -2,6 +2,7 @@ package com.piikii.output.web.avocado.parser
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.config.AvocadoProperties
+import com.piikii.output.web.avocado.parser.AvocadoOriginMapIdParser.Companion.ORIGIN_MAP_IP_REGEX
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 
@@ -29,23 +30,36 @@ interface AvocadoOriginMapIdParser {
             ?.toLongOrNull()
             ?.let { OriginMapId(it) }
     }
+
+    companion object {
+        const val ORIGIN_MAP_IP_REGEX = "\\d+"
+    }
 }
 
 @Component
 class MapUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
-    private val patternRegex: Regex = "${properties.url.regex.web}$PLACE_ID_REGEX".toRegex()
-    private val parseRegex: Regex = "${properties.url.regex.web}($PLACE_ID_REGEX)".toRegex()
+    private val regex: Regex = "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex()
 
     override fun pattern(): Regex {
-        return patternRegex
+        return regex
     }
 
     override fun parseOriginMapId(url: String): OriginMapId? {
-        return parseRegex.find(url).parseFromMatchResult()
+        return regex.find(url).parseFromMatchResult()
     }
 
-    companion object {
-        const val PLACE_ID_REGEX = "\\d+"
+}
+
+@Component
+class MapMobileUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
+    private val regex: Regex = "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)/home".toRegex()
+
+    override fun pattern(): Regex {
+        return regex
+    }
+
+    override fun parseOriginMapId(url: String): OriginMapId? {
+        return regex.find(url).parseFromMatchResult()
     }
 }
 

--- a/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
+++ b/piikii-output-web/avocado/src/main/kotlin/com/piikii/output/web/avocado/parser/AvocadoOriginMapIdParser.kt
@@ -38,10 +38,11 @@ interface AvocadoOriginMapIdParser {
 
 @Component
 class MapUrlIdParser(properties: AvocadoProperties) : AvocadoOriginMapIdParser {
-    private val regexes: List<Regex> = listOf(
-        "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
-        "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)/home".toRegex(),
-    )
+    private val regexes: List<Regex> =
+        listOf(
+            "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+            "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)/home".toRegex(),
+        )
 
     override fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? =
         takeIf { regexes.any { regex -> regex.matches(url) } }
@@ -59,8 +60,7 @@ class ShareUrlIdParser(
     private val idParameterRegex: Regex = "id=(\\d+)".toRegex()
     private val client: RestClient = RestClient.builder().build()
 
-    override fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? =
-        takeIf { regex.matches(url) }
+    override fun getParserBySupportedUrl(url: String): AvocadoOriginMapIdParser? = takeIf { regex.matches(url) }
 
     override fun parseOriginMapId(url: String): OriginMapId? {
         val response =

--- a/piikii-output-web/avocado/src/main/resources/avocado-config/application.yml
+++ b/piikii-output-web/avocado/src/main/resources/avocado-config/application.yml
@@ -5,6 +5,7 @@ avocado:
   url:
     regex:
       web: ${AVOCADO_WEB_URL_REGEX}
+      mobile-web: ${AVOCADO_MOBILE_WEB_URL_REGEX}
       share: ${AVOCADO_SHARE_URL_REGEX}
     api: ${AVOCADO_API_URL}
     referer: ${AVOCADO_REFERER_URL}

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -2,6 +2,7 @@ package com.piikii.output.web.avocado
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
+import com.piikii.output.web.avocado.parser.MapMobileUrlIdParser
 import com.piikii.output.web.avocado.parser.MapUrlIdParser
 import com.piikii.output.web.avocado.parser.ShareUrlIdParser
 import org.assertj.core.api.Assertions.assertThat
@@ -18,30 +19,44 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(classes = [TestConfiguration::class])
 class AvocadoPlaceAutoCompleteClientTest {
     @Autowired
-    lateinit var sharePlaceIdParser: ShareUrlIdParser
+    lateinit var shareUrlIdParser: ShareUrlIdParser
 
     @Autowired
-    lateinit var mapPlaceIdParser: MapUrlIdParser
+    lateinit var mapUrlIdParser: MapUrlIdParser
+
+    @Autowired
+    lateinit var mapMobileUrlIdParser: MapMobileUrlIdParser
 
     @Autowired
     lateinit var avocadoPlaceAutoCompleteClient: AvocadoPlaceAutoCompleteClient
 
     @Test
-    fun sharePlaceIdParserTest() {
+    fun shareUrlIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val parse = sharePlaceIdParser.parseOriginMapId(url)
+        val parse = shareUrlIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 
     @Test
-    fun mapPlaceIdParserTest() {
+    fun mapUrlIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val pattern = mapPlaceIdParser.pattern()
+        val pattern = mapUrlIdParser.pattern()
         assertThat(pattern.matches(url)).isTrue()
 
-        val parse = mapPlaceIdParser.parseOriginMapId(url)
+        val parse = mapUrlIdParser.parseOriginMapId(url)
+        println("parse = $parse")
+    }
+
+    @Test
+    fun mapMobileUrlIdParserTest() {
+        val url = "주소를 입력하세요"
+
+        val pattern = mapMobileUrlIdParser.pattern()
+        assertThat(pattern.matches(url)).isTrue()
+
+        val parse = mapMobileUrlIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 

--- a/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
+++ b/piikii-output-web/avocado/src/test/kotlin/com/piikii/output/web/avocado/AvocadoPlaceAutoCompleteClientTest.kt
@@ -2,7 +2,6 @@ package com.piikii.output.web.avocado
 
 import com.piikii.application.domain.place.OriginMapId
 import com.piikii.output.web.avocado.adapter.AvocadoPlaceAutoCompleteClient
-import com.piikii.output.web.avocado.parser.MapMobileUrlIdParser
 import com.piikii.output.web.avocado.parser.MapUrlIdParser
 import com.piikii.output.web.avocado.parser.ShareUrlIdParser
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +24,7 @@ class AvocadoPlaceAutoCompleteClientTest {
     lateinit var mapUrlIdParser: MapUrlIdParser
 
     @Autowired
-    lateinit var mapMobileUrlIdParser: MapMobileUrlIdParser
+    lateinit var mapMobileUrlIdParser: MapUrlIdParser
 
     @Autowired
     lateinit var avocadoPlaceAutoCompleteClient: AvocadoPlaceAutoCompleteClient
@@ -42,21 +41,10 @@ class AvocadoPlaceAutoCompleteClientTest {
     fun mapUrlIdParserTest() {
         val url = "주소를 입력하세요"
 
-        val pattern = mapUrlIdParser.pattern()
-        assertThat(pattern.matches(url)).isTrue()
+        val pattern = mapUrlIdParser.getParserBySupportedUrl(url)
+        assertThat(pattern).isNotNull()
 
         val parse = mapUrlIdParser.parseOriginMapId(url)
-        println("parse = $parse")
-    }
-
-    @Test
-    fun mapMobileUrlIdParserTest() {
-        val url = "주소를 입력하세요"
-
-        val pattern = mapMobileUrlIdParser.pattern()
-        assertThat(pattern.matches(url)).isTrue()
-
-        val parse = mapMobileUrlIdParser.parseOriginMapId(url)
         println("parse = $parse")
     }
 

--- a/piikii-output-web/avocado/src/test/resources/application-test.yml
+++ b/piikii-output-web/avocado/src/test/resources/application-test.yml
@@ -5,6 +5,7 @@ avocado:
   url:
     regex:
       web: ${AVOCADO_WEB_URL_REGEX}
+      mobile-web: ${AVOCADO_MOBILE_WEB_URL_REGEX}
       share: ${AVOCADO_SHARE_URL_REGEX}
     api: ${AVOCADO_API_URL}
     referer: ${AVOCADO_REFERER_URL}

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/adapter/LemonPlaceInfoResponse.kt
@@ -12,7 +12,7 @@ data class LemonPlaceInfoResponse(
     val isMapUser: String?,
     val isExist: Boolean?,
     val basicInfo: BasicInfo,
-    val comment: Comment,
+    val comment: Comment?,
     val menuInfo: MenuInfo,
     val photo: Photo,
 ) {
@@ -43,7 +43,7 @@ data class LemonPlaceInfoResponse(
         @JsonProperty("mainphotourl")
         val mainPhotoUrl: String,
         @JsonProperty("phonenum")
-        val phoneNumber: String,
+        val phoneNumber: String?,
         val address: Address,
         val homepage: String?,
         val category: Category,

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/config/LemonConfig.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/config/LemonConfig.kt
@@ -28,5 +28,6 @@ data class LemonUrl(
 ) {
     data class Regex(
         val web: String,
+        val mobileWeb: String,
     )
 }

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -8,10 +8,11 @@ import org.springframework.stereotype.Component
 class LemonOriginMapIdParser(
     properties: LemonProperties,
 ) {
-    private val regexes: List<Regex> = listOf(
-        "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
-        "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex()
-    )
+    private val regexes: List<Regex> =
+        listOf(
+            "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+            "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+        )
 
     fun isAutoCompleteSupportedUrl(url: String): Boolean = regexes.any { it.matches(url) }
 

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -13,9 +13,7 @@ class LemonOriginMapIdParser(
         "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex()
     )
 
-    fun isAutoCompleteSupportedUrl(url: String): Boolean {
-        return regexes.any { it.matches(url) }
-    }
+    fun isAutoCompleteSupportedUrl(url: String): Boolean = regexes.any { it.matches(url) }
 
     fun parseOriginMapId(url: String): OriginMapId? {
         return regexes.firstOrNull { it.matches(url) }

--- a/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
+++ b/piikii-output-web/lemon/src/main/kotlin/com/piikii/output/web/lemon/parser/LemonOriginMapIdParser.kt
@@ -8,18 +8,18 @@ import org.springframework.stereotype.Component
 class LemonOriginMapIdParser(
     properties: LemonProperties,
 ) {
-    private val patternRegex: Regex = "${properties.url.regex.web}$PLACE_ID_REGEX".toRegex()
-    private val parseRegex: Regex = "${properties.url.regex.web}($PLACE_ID_REGEX)".toRegex()
+    private val regexes: List<Regex> = listOf(
+        "${properties.url.regex.web}($ORIGIN_MAP_IP_REGEX)".toRegex(),
+        "${properties.url.regex.mobileWeb}($ORIGIN_MAP_IP_REGEX)".toRegex()
+    )
 
     fun isAutoCompleteSupportedUrl(url: String): Boolean {
-        return patternRegex.matches(url)
+        return regexes.any { it.matches(url) }
     }
 
     fun parseOriginMapId(url: String): OriginMapId? {
-        if (!isAutoCompleteSupportedUrl(url)) {
-            return null
-        }
-        return parseRegex.find(url)
+        return regexes.firstOrNull { it.matches(url) }
+            ?.find(url)
             ?.groupValues
             ?.getOrNull(1)
             ?.toLongOrNull()
@@ -27,6 +27,6 @@ class LemonOriginMapIdParser(
     }
 
     companion object {
-        const val PLACE_ID_REGEX = "\\d+"
+        const val ORIGIN_MAP_IP_REGEX = "\\d+"
     }
 }

--- a/piikii-output-web/lemon/src/main/resources/lemon-config/application.yml
+++ b/piikii-output-web/lemon/src/main/resources/lemon-config/application.yml
@@ -2,4 +2,5 @@ lemon:
   url:
     regex:
       web: ${LEMON_WEB_URL_REGEX}
+      mobile-web: ${LEMON_MOBILE_WEB_URL_REGEX}
     api: ${LEMON_API_URL}

--- a/piikii-output-web/lemon/src/test/resources/application-test.yml
+++ b/piikii-output-web/lemon/src/test/resources/application-test.yml
@@ -2,4 +2,5 @@ lemon:
   url:
     regex:
       web: ${LEMON_WEB_URL_REGEX}
+      mobile-web: ${LEMON_MOBILE_WEB_URL_REGEX}
     api: ${LEMON_API_URL}


### PR DESCRIPTION
## 이슈

from #95 

LEMON/AVOCADO Map URL에는 2가지 종류가 있습니다.
- pc (web)
- mobile (web)

처음엔 pc web URL 패턴만 지원했는데, 이번에 mobile web URL 패턴 지원기능을 추가했습니다.


## 변경 사항

- Mobile URL 패턴 및 파싱 로직 추가
- Place/OriginPlace Entity 내 썸네일 링크 길이 제한 확장 (Lob)

## 스크린샷

## 부연 설명

## 체크리스트

- [ ] Lint 적용 여부
- [ ] 빌드 성공 여부
- [ ] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [ ] PR에 대해 구체적으로 설명이 되어있는가
