### PR TITLE
test: 테스트 템플릿 추가

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           SECRET_MANAGER_TOKEN: ${{ secrets.SECRET_MANAGER_TOKEN }}
           SECRET_MANAGER_WORKSPACE: ${{ secrets.SECRET_MANAGER_WORKSPACE }}
-        run: ./gradlew build --debug
+        run: ./gradlew build --info
 
       - name: Set build status output
         id: set_status

--- a/piikii-bootstrap/build.gradle.kts
+++ b/piikii-bootstrap/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":piikii-output-web:lemon"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+
+    testImplementation(project(":piikii-application"))
 }
 
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {

--- a/piikii-bootstrap/src/main/kotlin/com/piikii/bootstrap/secret/SecretProcessor.kt
+++ b/piikii-bootstrap/src/main/kotlin/com/piikii/bootstrap/secret/SecretProcessor.kt
@@ -62,7 +62,7 @@ class SecretProcessor : EnvironmentPostProcessor {
         const val BEARER_TOKEN_PREFIX = "Bearer"
         const val SECRET_MANAGER_URL = "https://app.infisical.com/api/v3"
 
-        val SUPPORT_PROFILES = setOf("local", "dev", "prod")
+        val SUPPORT_PROFILES = setOf("local", "test", "prod")
     }
 }
 

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/AcceptanceTestHelper.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/AcceptanceTestHelper.kt
@@ -13,10 +13,10 @@ abstract class AcceptanceTestHelper(
     private val acceptanceTestActor: AcceptanceTestActor,
     private val acceptanceTestAsserter: AcceptanceTestAsserter,
 ) {
-    fun act(
+    fun <T> act(
         method: HttpMethod,
         uri: String,
-        requestBody: Any?,
+        requestBody: T?,
         parameters: Map<String, String> = emptyMap(),
     ): ResultActions {
         return acceptanceTestActor.execute(

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/AcceptanceTestHelper.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/AcceptanceTestHelper.kt
@@ -1,0 +1,44 @@
+package com.piikii.bootstrap
+
+import com.piikii.bootstrap.actor.AcceptanceTestActor
+import com.piikii.bootstrap.annotation.AcceptanceTest
+import com.piikii.bootstrap.asserter.AcceptanceTestAsserter
+import com.piikii.input.http.controller.dto.ResponseForm
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultMatcher
+
+@AcceptanceTest
+abstract class AcceptanceTestHelper(
+    private val acceptanceTestActor: AcceptanceTestActor,
+    private val acceptanceTestAsserter: AcceptanceTestAsserter,
+) {
+    fun act(
+        method: HttpMethod,
+        uri: String,
+        requestBody: Any?,
+        parameters: Map<String, String> = emptyMap(),
+    ): ResultActions {
+        return acceptanceTestActor.execute(
+            method = method,
+            uri = uri,
+            requestBody = requestBody,
+            parameters = parameters,
+        )
+    }
+
+    fun <T> assert(
+        resultActions: ResultActions,
+        expectedStatus: ResultMatcher,
+        responseDto: ResponseForm<T>,
+    ) {
+        acceptanceTestAsserter.execute(resultActions, expectedStatus, responseDto)
+    }
+
+    fun assert(
+        resultActions: ResultActions,
+        expectedStatus: ResultMatcher,
+    ) {
+        acceptanceTestAsserter.execute(resultActions, expectedStatus)
+    }
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/AcceptanceTestActor.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/AcceptanceTestActor.kt
@@ -1,0 +1,13 @@
+package com.piikii.bootstrap.actor
+
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.ResultActions
+
+interface AcceptanceTestActor {
+    fun execute(
+        method: HttpMethod,
+        uri: String,
+        requestBody: Any?,
+        parameters: Map<String, String>,
+    ): ResultActions
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/AcceptanceTestActor.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/AcceptanceTestActor.kt
@@ -4,10 +4,10 @@ import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.ResultActions
 
 interface AcceptanceTestActor {
-    fun execute(
+    fun <T> execute(
         method: HttpMethod,
         uri: String,
-        requestBody: Any?,
+        requestBody: T?,
         parameters: Map<String, String>,
     ): ResultActions
 }

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/MockMvcActor.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/MockMvcActor.kt
@@ -1,0 +1,62 @@
+package com.piikii.bootstrap.actor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.boot.test.context.TestComponent
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+
+@TestComponent
+class MockMvcActor(
+    private val objectMapper: ObjectMapper,
+    private val mockMvc: MockMvc,
+) : AcceptanceTestActor {
+    override fun execute(
+        method: HttpMethod,
+        uri: String,
+        requestBody: Any?,
+        parameters: Map<String, String>,
+    ): ResultActions {
+        val requestBuilder = createRequestBuilder(method, uri)
+        return mockMvc.perform(configureRequest(requestBuilder, requestBody, parameters))
+            .andDo(MockMvcResultHandlers.print())
+    }
+
+    private fun createRequestBuilder(
+        method: HttpMethod,
+        uri: String,
+    ): MockHttpServletRequestBuilder =
+        when (method) {
+            HttpMethod.GET -> MockMvcRequestBuilders.get(uri)
+            HttpMethod.POST -> MockMvcRequestBuilders.post(uri)
+            HttpMethod.PUT -> MockMvcRequestBuilders.put(uri)
+            HttpMethod.PATCH -> MockMvcRequestBuilders.patch(uri)
+            HttpMethod.DELETE -> MockMvcRequestBuilders.delete(uri)
+            else -> throw IllegalArgumentException("Unsupported HTTP method: $method")
+        }
+
+    private fun configureRequest(
+        requestBuilder: MockHttpServletRequestBuilder,
+        requestBody: Any?,
+        parameters: Map<String, String>,
+    ): MockHttpServletRequestBuilder =
+        requestBuilder.apply {
+            contentType(MediaType.APPLICATION_JSON)
+            accept(MediaType.APPLICATION_JSON)
+            requestBody?.let { content(objectMapper.writeValueAsString(it)) }
+            if (parameters.isNotEmpty()) {
+                params(toMultiValueMap(parameters))
+            }
+        }
+
+    private fun toMultiValueMap(map: Map<String, String>): MultiValueMap<String, String> =
+        LinkedMultiValueMap<String, String>().apply {
+            map.forEach { (key, value) -> add(key, value) }
+        }
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/MockMvcActor.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/actor/MockMvcActor.kt
@@ -17,10 +17,10 @@ class MockMvcActor(
     private val objectMapper: ObjectMapper,
     private val mockMvc: MockMvc,
 ) : AcceptanceTestActor {
-    override fun execute(
+    override fun <T> execute(
         method: HttpMethod,
         uri: String,
-        requestBody: Any?,
+        requestBody: T?,
         parameters: Map<String, String>,
     ): ResultActions {
         val requestBuilder = createRequestBuilder(method, uri)

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/annotation/AcceptanceTest.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/annotation/AcceptanceTest.kt
@@ -7,11 +7,13 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestConstructor
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @ComponentScan(basePackages = ["com.piikii.*"])
 @SpringBootTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @AutoConfigureMockMvc
 @EnableAutoConfiguration
 @ContextConfiguration(classes = [TestConfiguration::class])

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/annotation/AcceptanceTest.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/annotation/AcceptanceTest.kt
@@ -1,0 +1,19 @@
+package com.piikii.bootstrap.annotation
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ComponentScan(basePackages = ["com.piikii.*"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
+@ContextConfiguration(classes = [TestConfiguration::class])
+@ActiveProfiles("dev")
+annotation class AcceptanceTest

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/annotation/AcceptanceTest.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/annotation/AcceptanceTest.kt
@@ -15,5 +15,5 @@ import org.springframework.test.context.ContextConfiguration
 @AutoConfigureMockMvc
 @EnableAutoConfiguration
 @ContextConfiguration(classes = [TestConfiguration::class])
-@ActiveProfiles("dev")
+@ActiveProfiles("test")
 annotation class AcceptanceTest

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/asserter/AcceptanceTestAsserter.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/asserter/AcceptanceTestAsserter.kt
@@ -1,0 +1,18 @@
+package com.piikii.bootstrap.asserter
+
+import com.piikii.input.http.controller.dto.ResponseForm
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultMatcher
+
+interface AcceptanceTestAsserter {
+    fun <T> execute(
+        result: ResultActions,
+        expectedStatus: ResultMatcher,
+        responseDto: ResponseForm<T>,
+    )
+
+    fun execute(
+        result: ResultActions,
+        expectedStatus: ResultMatcher,
+    )
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/asserter/MockMvcAsserter.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/asserter/MockMvcAsserter.kt
@@ -1,0 +1,46 @@
+package com.piikii.bootstrap.asserter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.piikii.input.http.controller.dto.ResponseForm
+import org.springframework.boot.test.context.TestComponent
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultMatcher
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+
+@TestComponent
+class MockMvcAsserter(
+    private val objectMapper: ObjectMapper,
+) : AcceptanceTestAsserter {
+    override fun <T> execute(
+        result: ResultActions,
+        expectedStatus: ResultMatcher,
+        responseDto: ResponseForm<T>,
+    ) {
+        result.andExpect(expectedStatus)
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andExpect(jsonPath("$.data").exists())
+
+        if (responseDto.data != null) {
+            val jsonData = objectMapper.writeValueAsString(responseDto.data)
+            val dataMap = objectMapper.readValue(jsonData, Map::class.java)
+
+            dataMap.forEach { (key, _) ->
+                result.andExpect(jsonPath("$.data.$key").exists())
+            }
+        } else {
+            result.andExpect(jsonPath("$.data").exists())
+        }
+    }
+
+    override fun execute(
+        result: ResultActions,
+        expectedStatus: ResultMatcher,
+    ) {
+        result.andExpectAll(
+            expectedStatus,
+            jsonPath("$.message").exists(),
+            jsonPath("$.cause").exists(),
+            jsonPath("$.timestamp").exists(),
+        )
+    }
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/controller/RoomApiTest.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/controller/RoomApiTest.kt
@@ -8,14 +8,11 @@ import com.piikii.bootstrap.fixture.dto.room.getSaveRequestFixture
 import com.piikii.bootstrap.fixture.dto.room.getSaveResponseFixture
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 class RoomApiTest(
-    @Autowired
     mockMvcActor: MockMvcActor,
-    @Autowired
     mockMvcAsserter: MockMvcAsserter,
 ) : AcceptanceTestHelper(mockMvcActor, mockMvcAsserter) {
     @Nested

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/controller/RoomApiTest.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/controller/RoomApiTest.kt
@@ -1,0 +1,55 @@
+package com.piikii.bootstrap.controller
+
+import com.piikii.bootstrap.AcceptanceTestHelper
+import com.piikii.bootstrap.actor.MockMvcActor
+import com.piikii.bootstrap.asserter.MockMvcAsserter
+import com.piikii.bootstrap.fixture.dto.room.getNotValidSaveRequestFixture
+import com.piikii.bootstrap.fixture.dto.room.getSaveRequestFixture
+import com.piikii.bootstrap.fixture.dto.room.getSaveResponseFixture
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class RoomApiTest
+    @Autowired
+    constructor(
+        mockMvcActor: MockMvcActor,
+        mockMvcAsserter: MockMvcAsserter,
+    ) : AcceptanceTestHelper(mockMvcActor, mockMvcAsserter) {
+        @Nested
+        inner class Success {
+            @Test
+            fun `방 생성 성공`() {
+                // Arrange && Act
+                val resultActions = act(HttpMethod.POST, BASE_URL, getSaveRequestFixture())
+
+                // Assert
+                assert(
+                    resultActions = resultActions,
+                    expectedStatus = status().isCreated,
+                    responseDto = getSaveResponseFixture(),
+                )
+            }
+        }
+
+        @Nested
+        inner class Fail {
+            @Test
+            fun `방 생성 실패 - 값 범위를 초과함`() {
+                // Arrange && Act
+                val resultActions = act(HttpMethod.POST, BASE_URL, getNotValidSaveRequestFixture())
+
+                // Assert
+                assert(
+                    resultActions = resultActions,
+                    expectedStatus = status().is4xxClientError,
+                )
+            }
+        }
+
+        companion object {
+            private const val BASE_URL = "/v1/rooms"
+        }
+    }

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/controller/RoomApiTest.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/controller/RoomApiTest.kt
@@ -12,44 +12,44 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-class RoomApiTest
+class RoomApiTest(
     @Autowired
-    constructor(
-        mockMvcActor: MockMvcActor,
-        mockMvcAsserter: MockMvcAsserter,
-    ) : AcceptanceTestHelper(mockMvcActor, mockMvcAsserter) {
-        @Nested
-        inner class Success {
-            @Test
-            fun `방 생성 성공`() {
-                // Arrange && Act
-                val resultActions = act(HttpMethod.POST, BASE_URL, getSaveRequestFixture())
+    mockMvcActor: MockMvcActor,
+    @Autowired
+    mockMvcAsserter: MockMvcAsserter,
+) : AcceptanceTestHelper(mockMvcActor, mockMvcAsserter) {
+    @Nested
+    inner class Success {
+        @Test
+        fun `방 생성 성공`() {
+            // Arrange && Act
+            val resultActions = act(HttpMethod.POST, BASE_URL, getSaveRequestFixture())
 
-                // Assert
-                assert(
-                    resultActions = resultActions,
-                    expectedStatus = status().isCreated,
-                    responseDto = getSaveResponseFixture(),
-                )
-            }
-        }
-
-        @Nested
-        inner class Fail {
-            @Test
-            fun `방 생성 실패 - 값 범위를 초과함`() {
-                // Arrange && Act
-                val resultActions = act(HttpMethod.POST, BASE_URL, getNotValidSaveRequestFixture())
-
-                // Assert
-                assert(
-                    resultActions = resultActions,
-                    expectedStatus = status().is4xxClientError,
-                )
-            }
-        }
-
-        companion object {
-            private const val BASE_URL = "/v1/rooms"
+            // Assert
+            assert(
+                resultActions = resultActions,
+                expectedStatus = status().isCreated,
+                responseDto = getSaveResponseFixture(),
+            )
         }
     }
+
+    @Nested
+    inner class Fail {
+        @Test
+        fun `방 생성 실패 - 값 범위를 초과함`() {
+            // Arrange && Act
+            val resultActions = act(HttpMethod.POST, BASE_URL, getNotValidSaveRequestFixture())
+
+            // Assert
+            assert(
+                resultActions = resultActions,
+                expectedStatus = status().is4xxClientError,
+            )
+        }
+    }
+
+    companion object {
+        private const val BASE_URL = "/v1/rooms"
+    }
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/fixture/dto/room/RequestFixtures.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/fixture/dto/room/RequestFixtures.kt
@@ -7,7 +7,6 @@ internal fun getSaveRequestFixture(): RoomSaveRequestForm {
     return RoomSaveRequestForm(
         name = "방 테스트 1",
         message = "방 테스트 메세지 1",
-        address = "우리집",
         thumbnailLink = "",
         password = Password(value = "0001"),
     )
@@ -17,7 +16,6 @@ internal fun getNotValidSaveRequestFixture(): RoomSaveRequestForm {
     return RoomSaveRequestForm(
         name = "방 테스트 1",
         message = "방 테스트 메세지 1",
-        address = "우리집",
         thumbnailLink = "",
         password = Password(value = "0001010100101"),
     )

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/fixture/dto/room/RequestFixtures.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/fixture/dto/room/RequestFixtures.kt
@@ -1,0 +1,24 @@
+package com.piikii.bootstrap.fixture.dto.room
+
+import com.piikii.application.domain.room.Password
+import com.piikii.application.port.input.dto.request.RoomSaveRequestForm
+
+internal fun getSaveRequestFixture(): RoomSaveRequestForm {
+    return RoomSaveRequestForm(
+        name = "방 테스트 1",
+        message = "방 테스트 메세지 1",
+        address = "우리집",
+        thumbnailLink = "",
+        password = Password(value = "0001"),
+    )
+}
+
+internal fun getNotValidSaveRequestFixture(): RoomSaveRequestForm {
+    return RoomSaveRequestForm(
+        name = "방 테스트 1",
+        message = "방 테스트 메세지 1",
+        address = "우리집",
+        thumbnailLink = "",
+        password = Password(value = "0001010100101"),
+    )
+}

--- a/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/fixture/dto/room/ResponseFixtures.kt
+++ b/piikii-bootstrap/src/test/kotlin/com/piikii/bootstrap/fixture/dto/room/ResponseFixtures.kt
@@ -1,0 +1,13 @@
+package com.piikii.bootstrap.fixture.dto.room
+
+import com.piikii.application.port.input.dto.response.SaveRoomResponse
+import com.piikii.input.http.controller.dto.ResponseForm
+import java.util.UUID
+
+internal fun getSaveResponseFixture(): ResponseForm<SaveRoomResponse> {
+    return ResponseForm(
+        SaveRoomResponse(
+            roomUid = UUID.randomUUID(),
+        ),
+    )
+}

--- a/piikii-bootstrap/src/test/resources/application-dev.yml
+++ b/piikii-bootstrap/src/test/resources/application-dev.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: dev

--- a/piikii-bootstrap/src/test/resources/application-dev.yml
+++ b/piikii-bootstrap/src/test/resources/application-dev.yml
@@ -1,4 +1,0 @@
-spring:
-  config:
-    activate:
-      on-profile: dev

--- a/piikii-bootstrap/src/test/resources/application.yml
+++ b/piikii-bootstrap/src/test/resources/application.yml
@@ -5,11 +5,12 @@ spring:
       - classpath:storage-config/application.yml
       - classpath:lemon-config/application.yml
       - classpath:avocado-config/application.yml
-      - classpath:database-config/application-dev.yml
+      - classpath:database-config/application-test.yml
   application:
     name: "piikii"
   messages:
     encoding: UTF-8
+
 
 secret:
   token: ${SECRET_MANAGER_TOKEN}

--- a/piikii-bootstrap/src/test/resources/application.yml
+++ b/piikii-bootstrap/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    import:
+      - classpath:http-config/application.yml
+      - classpath:storage-config/application.yml
+      - classpath:lemon-config/application.yml
+      - classpath:avocado-config/application.yml
+      - classpath:database-config/application-dev.yml
+  application:
+    name: "piikii"
+  messages:
+    encoding: UTF-8
+
+secret:
+  token: ${SECRET_MANAGER_TOKEN}
+  workspaceId: ${SECRET_MANAGER_WORKSPACE}

--- a/piikii-output-persistence/postgresql/src/main/resources/database-config/application-dev.yml
+++ b/piikii-output-persistence/postgresql/src/main/resources/database-config/application-dev.yml
@@ -1,0 +1,29 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    hikari:
+      pool-name: Hikari-PostgreSQL
+      maximum-pool-size: 20
+      minimum-idle: 10
+      idle-timeout: 1000
+      max-lifetime: 200000
+      connection-timeout: 30000
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database: postgresql
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        temp.use_jdbc_metadata_defaults: false
+        jdbc.lob.non_contextual_creation: true
+        generate_statistics: true
+        format_sql: true
+    show-sql: true

--- a/piikii-output-persistence/postgresql/src/main/resources/database-config/application-test.yml
+++ b/piikii-output-persistence/postgresql/src/main/resources/database-config/application-test.yml
@@ -19,7 +19,7 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     database: postgresql
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         temp.use_jdbc_metadata_defaults: false

--- a/piikii-output-persistence/postgresql/src/main/resources/database-config/application-test.yml
+++ b/piikii-output-persistence/postgresql/src/main/resources/database-config/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   config:
     activate:
-      on-profile: dev
+      on-profile: test
 
   datasource:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 이슈



## 변경 사항

- 인수 테스트 템플릿을 만들었습니다.
    - 현재 모양은 엄밀히 따지면 E2E에 가깝습니다. 사용자 시나리오에 따른 테스트를 쉽게 만들 수 있는 템플릿이며 빠르게 인수테스트를 생성하기 위함입니다.

## 스크린샷

## 부연 설명

#### `AcceptanceTestHelper.kt`
- 이 객체는 `mockMvc`의 요청과 검증을 간소화하기 위한 객체입니다.
  - 사용자(~~~ApiTest.kt)로부터 인수테스트 기술 구현체(~~~actor, ~~~asserter)를 주입받아 사용자가 지정한 테스팅 기술에 대한 코드를 간소화하여 사용할 수 있습니다.

#### `AcceptanceTestActor.kt`
- 위 객체는 테스팅 기술의 코드를 간소화 하고 실행하는 객체입니다.
  - HttpMethod, URI, RequestBody, Parameter 를 매개변수로 받아 실제 API를 호출합니다.

#### `AcceptanceTestAsserter.kt`
- 위 객체는 response를 검증하는 객체입니다. 
    - ResponseDTO를 검증하고자할 땐 (result, expectedStatus, responseDto)를 매개변수로 넣은 후 검증 메서드를 사용하면 됩니다.
    - 예외를 검증하고자할 땐 (result, expectedStatus)를 매개변수로 넣은 후 검증 메서드를 사용하면 됩니다.

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
