### PR TITLE
fix: CORS credentials

### DIFF
--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/web/config/WebConfig.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/web/config/WebConfig.kt
@@ -11,7 +11,7 @@ class WebConfig : WebMvcConfigurer {
             .allowedOrigins("*")
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
-            .allowCredentials(true)
+            .allowCredentials(false)
             .maxAge(3600)
     }
 }


### PR DESCRIPTION
## 이슈

## 변경 사항

- CORS 허용 정책 중 Credentials를 필수로 받던 옵션을 해제합니다.

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
