### PR TITLE
Metric 모니터링을 위한 Actuator 설정

### DIFF
--- a/piikii-bootstrap/build.gradle.kts
+++ b/piikii-bootstrap/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     implementation(project(":piikii-output-web:tmap"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     testImplementation(project(":piikii-application"))
 }

--- a/piikii-bootstrap/src/main/resources/application-actuator.yml
+++ b/piikii-bootstrap/src/main/resources/application-actuator.yml
@@ -1,0 +1,31 @@
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      base-path: /_status
+      exposure:
+        include: health, metrics, prometheus
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      percentiles:
+        http.server.requests: 0.5, 0.8, 0.95, 0.99, 1.0
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+    defaults:
+      enabled: false
+    ping:
+      enabled: true
+  endpoint:
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+    health:
+      enabled: true
+      probes:
+        enabled: true

--- a/piikii-bootstrap/src/main/resources/application.yml
+++ b/piikii-bootstrap/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
       - classpath:lemon-config/application.yml
       - classpath:avocado-config/application.yml
       - classpath:tmap-config/application.yml
+      - classpath:application-actuator.yml
   application:
     name: "piikii"
   messages:


### PR DESCRIPTION
## 이슈

from #9 


## 변경 사항

- Metric 모니터링을 위한 Actuator, Micrometer for Prometheus 의존성을 추가했습니다.
- 간단한 Actuator 설정을 추가했습니다.


## 스크린샷

## 부연 설명

## 체크리스트

- [ ] Lint 적용 여부
- [ ] 빌드 성공 여부
- [ ] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [ ] PR에 대해 구체적으로 설명이 되어있는가
