### PR TITLE
fix: 스케줄 생성 시 LongTypeId로 인한 버그 수정

### DIFF
--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/schedule/ScheduleService.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/schedule/ScheduleService.kt
@@ -22,7 +22,7 @@ class ScheduleService(
     ) {
         val schedulesToRegister = request.toDomains(roomUid)
         deleteSchedules(roomUid, schedulesToRegister)
-        schedulesToRegister.partition { it.id == null }.let { (newSchedules, updatedSchedules) ->
+        schedulesToRegister.partition { it.id.getValue() == 0L }.let { (newSchedules, updatedSchedules) ->
             scheduleCommandPort.saveSchedules(newSchedules)
             scheduleCommandPort.updateSchedules(updatedSchedules)
         }

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/ScheduleRequest.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/ScheduleRequest.kt
@@ -39,17 +39,8 @@ data class RegisterScheduleRequest(
     val sequence: Int,
 ) {
     fun toDomain(roomUid: UuidTypeId): Schedule {
-        if (this.scheduleId == null) {
-            return Schedule(
-                id = LongTypeId(0L),
-                roomUid = roomUid,
-                name = this.name,
-                sequence = this.sequence,
-                type = ScheduleType.valueOf(this.type.name),
-            )
-        }
         return Schedule(
-            id = LongTypeId(this.scheduleId),
+            id = LongTypeId(this.scheduleId ?: 0L),
             roomUid = roomUid,
             name = this.name,
             sequence = this.sequence,

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/ScheduleRequest.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/ScheduleRequest.kt
@@ -39,6 +39,15 @@ data class RegisterScheduleRequest(
     val sequence: Int,
 ) {
     fun toDomain(roomUid: UuidTypeId): Schedule {
+        if (this.scheduleId == null) {
+            return Schedule(
+                id = LongTypeId(0L),
+                roomUid = roomUid,
+                name = this.name,
+                sequence = this.sequence,
+                type = ScheduleType.valueOf(this.type.name),
+            )
+        }
         return Schedule(
             id = LongTypeId(this.scheduleId),
             roomUid = roomUid,


### PR DESCRIPTION
## 이슈

## 변경 사항

- 스케줄 생성 시 `Reqeuset Body`에 scheduleId 값을 넣지 않도록했기 때문에
  - Scheule 도메인의 `toDomain()`메서드 내에서 `LongTypeId()`생성자를 호출할 때 예외가 터지게 됐습니다.
  - 이를 해결하고자 스케줄 생성 시 의미없는 기본 값을 지정하여 NPE Catch 예외를 회피하도록 변경했습니다.

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
