### PR TITLE
fix: Resolve Id Parsing Error In OriginPlace

### DIFF
--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
@@ -32,8 +32,7 @@ value class OriginMapId(val value: String) {
             id: LongTypeId,
             origin: Origin,
         ): OriginMapId {
-            val originMapId = OriginMapId("${origin.prefix}$SEPARATOR${id.getValue()}")
-            return originMapId
+            return OriginMapId("${origin.prefix}$SEPARATOR${id.getValue()}")
         }
     }
 }

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/place/OriginPlace.kt
@@ -32,7 +32,8 @@ value class OriginMapId(val value: String) {
             id: LongTypeId,
             origin: Origin,
         ): OriginMapId {
-            return OriginMapId("${origin.prefix}$SEPARATOR$id")
+            val originMapId = OriginMapId("${origin.prefix}$SEPARATOR${id.getValue()}")
+            return originMapId
         }
     }
 }


### PR DESCRIPTION
## 이슈

## 변경 사항

- OriginPlace RestClient 요청에 사용되는 `id`필드를 `LongTypeId(123984)`와 같이 타입 네이밍까지 스트링으로 포함되는 버그를 수정합니다.

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
