### PR TITLE
feat: 장소 이미지 추가 시, 자동완성 된 장소 이미지도 받을 수 있도록 기능 추가

### DIFF
--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/image/ImageFolderType.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/image/ImageFolderType.kt
@@ -1,0 +1,6 @@
+package com.piikii.application.domain.image
+
+enum class ImageFolderType {
+    ROOM,
+    PLACE,
+}

--- a/piikii-application/src/main/kotlin/com/piikii/application/domain/image/ImageUploadService.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/domain/image/ImageUploadService.kt
@@ -1,0 +1,23 @@
+package com.piikii.application.domain.image
+
+import com.piikii.application.port.input.ImageUploadUseCase
+import com.piikii.application.port.output.objectstorage.ObjectStoragePort
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class ImageUploadService(
+    private val objectStoragePort: ObjectStoragePort,
+) : ImageUploadUseCase {
+    override fun upload(
+        images: List<MultipartFile>?,
+        imageFolderType: ImageFolderType,
+    ): List<String> {
+        return images?.let {
+            objectStoragePort.uploadAll(
+                imageFolderType = imageFolderType,
+                multipartFiles = it,
+            ).get()
+        } ?: emptyList()
+    }
+}

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/ImageUploadUseCase.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/ImageUploadUseCase.kt
@@ -1,0 +1,11 @@
+package com.piikii.application.port.input
+
+import com.piikii.application.domain.image.ImageFolderType
+import org.springframework.web.multipart.MultipartFile
+
+interface ImageUploadUseCase {
+    fun upload(
+        images: List<MultipartFile>?,
+        imageFolderType: ImageFolderType,
+    ): List<String>
+}

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/PlaceUseCase.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/PlaceUseCase.kt
@@ -12,7 +12,7 @@ interface PlaceUseCase {
     fun addPlace(
         targetRoomUid: UuidTypeId,
         addPlaceRequest: AddPlaceRequest,
-        placeImages: List<MultipartFile>?,
+        placeImageUrls: List<String>,
     ): List<PlaceResponse>
 
     fun findAllByRoomUidGroupByPlaceType(roomUid: UuidTypeId): List<ScheduleTypeGroupResponse>

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/PlaceRequest.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/input/dto/request/PlaceRequest.kt
@@ -55,19 +55,22 @@ data class AddPlaceRequest(
     val openingHours: String?,
     @field:Schema(description = "Place 정보 출처", example = "AVOCADO")
     val origin: Origin = Origin.MANUAL,
+    @field:Schema(description = "자동완성에서 가져온 장소 이미지 URL 리스트")
+    val autoCompletedPlaceImageUrls: List<String> = emptyList(),
 ) {
     fun toDomain(
         roomUid: UuidTypeId,
         scheduleId: LongTypeId,
         imageUrls: List<String>,
     ): Place {
+        val thumbnailLinks = ThumbnailLinks(imageUrls + autoCompletedPlaceImageUrls)
         return Place(
             id = LongTypeId(0L),
             roomUid = roomUid,
             scheduleId = scheduleId,
             name = name,
             url = url,
-            thumbnailLinks = ThumbnailLinks(imageUrls),
+            thumbnailLinks = thumbnailLinks,
             address = address,
             phoneNumber = phoneNumber,
             starGrade = starGrade,

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/output/objectstorage/BucketFolderType.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/output/objectstorage/BucketFolderType.kt
@@ -1,6 +1,0 @@
-package com.piikii.application.port.output.objectstorage
-
-enum class BucketFolderType {
-    ROOM,
-    PLACE,
-}

--- a/piikii-application/src/main/kotlin/com/piikii/application/port/output/objectstorage/ObjectStoragePort.kt
+++ b/piikii-application/src/main/kotlin/com/piikii/application/port/output/objectstorage/ObjectStoragePort.kt
@@ -1,22 +1,23 @@
 package com.piikii.application.port.output.objectstorage
 
+import com.piikii.application.domain.image.ImageFolderType
 import org.springframework.web.multipart.MultipartFile
 import java.util.concurrent.Future
 
 interface ObjectStoragePort {
     fun uploadAll(
-        bucketFolderType: BucketFolderType,
+        imageFolderType: ImageFolderType,
         multipartFiles: List<MultipartFile>,
     ): Future<List<String>>
 
     fun updateAllByUrls(
-        bucketFolderType: BucketFolderType,
+        imageFolderType: ImageFolderType,
         deleteTargetUrls: List<String>,
         newMultipartFiles: List<MultipartFile>,
     ): Future<List<String>>
 
     fun deleteAllByUrls(
-        bucketFolderType: BucketFolderType,
+        imageFolderType: ImageFolderType,
         deleteTargetUrls: List<String>,
     )
 }

--- a/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/PlaceApi.kt
+++ b/piikii-input-http/src/main/kotlin/com/piikii/input/http/controller/PlaceApi.kt
@@ -2,6 +2,8 @@ package com.piikii.input.http.controller
 
 import com.piikii.application.domain.generic.LongTypeId
 import com.piikii.application.domain.generic.UuidTypeId
+import com.piikii.application.domain.image.ImageFolderType
+import com.piikii.application.port.input.ImageUploadUseCase
 import com.piikii.application.port.input.PlaceUseCase
 import com.piikii.application.port.input.dto.request.AddPlaceRequest
 import com.piikii.application.port.input.dto.request.ModifyPlaceRequest
@@ -31,6 +33,7 @@ import java.util.UUID
 @RequestMapping("/v1/rooms/{roomUid}/places")
 class PlaceApi(
     private val placeUseCase: PlaceUseCase,
+    private val imageUploadUseCase: ImageUploadUseCase,
 ) : PlaceDocs {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -39,7 +42,8 @@ class PlaceApi(
         @Valid @NotNull @RequestPart addPlaceRequest: AddPlaceRequest,
         @RequestPart(required = false) placeImages: List<MultipartFile>?,
     ): ResponseForm<List<PlaceResponse>> {
-        return ResponseForm(placeUseCase.addPlace(UuidTypeId(roomUid), addPlaceRequest, placeImages))
+        val placeImageUrls = imageUploadUseCase.upload(placeImages, ImageFolderType.PLACE)
+        return ResponseForm(placeUseCase.addPlace(UuidTypeId(roomUid), addPlaceRequest, placeImageUrls))
     }
 
     @GetMapping

--- a/piikii-output-storage/ncp/src/main/kotlin/com/piikii/output/storage/ncp/adapter/NcpObjectStorageAdapter.kt
+++ b/piikii-output-storage/ncp/src/main/kotlin/com/piikii/output/storage/ncp/adapter/NcpObjectStorageAdapter.kt
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.DeleteObjectRequest
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
-import com.piikii.application.port.output.objectstorage.BucketFolderType
+import com.piikii.application.domain.image.ImageFolderType
 import com.piikii.application.port.output.objectstorage.ObjectStoragePort
 import com.piikii.output.storage.ncp.config.NcpProperties
 import com.piikii.output.storage.ncp.config.StorageConfig
@@ -22,13 +22,13 @@ class NcpObjectStorageAdapter(
 ) : ObjectStoragePort {
     @Async("AsyncStorageExecutor")
     override fun uploadAll(
-        bucketFolderType: BucketFolderType,
+        imageFolderType: ImageFolderType,
         multipartFiles: List<MultipartFile>,
     ): Future<List<String>> {
         val contentUrls = mutableListOf<String>()
 
         for (multipartFile in multipartFiles) {
-            val folderName = getFolderName(bucketFolderType)
+            val folderName = getFolderName(imageFolderType)
             val fileName = getFileName(multipartFile)
             val objectKey = createObjectKey(folderName, fileName)
 
@@ -48,17 +48,17 @@ class NcpObjectStorageAdapter(
 
     @Async("TaskExecutorForExternalStorage")
     override fun updateAllByUrls(
-        bucketFolderType: BucketFolderType,
+        imageFolderType: ImageFolderType,
         deleteTargetUrls: List<String>,
         newMultipartFiles: List<MultipartFile>,
     ): Future<List<String>> {
-        deleteAllByUrls(bucketFolderType, deleteTargetUrls)
-        return uploadAll(bucketFolderType, newMultipartFiles)
+        deleteAllByUrls(imageFolderType, deleteTargetUrls)
+        return uploadAll(imageFolderType, newMultipartFiles)
     }
 
     @Async("TaskExecutorForExternalStorage")
     override fun deleteAllByUrls(
-        bucketFolderType: BucketFolderType,
+        imageFolderType: ImageFolderType,
         deleteTargetUrls: List<String>,
     ) {
         val storageClient = storageConfig.storageClient()
@@ -71,10 +71,10 @@ class NcpObjectStorageAdapter(
 
     private fun getFileName(multipartFile: MultipartFile) = "${multipartFile.originalFilename}"
 
-    private fun getFolderName(bucketFolderType: BucketFolderType): String {
-        return when (bucketFolderType) {
-            BucketFolderType.ROOM -> ncpProperties.bucket.folder.roomFolder
-            BucketFolderType.PLACE -> ncpProperties.bucket.folder.placeFolder
+    private fun getFolderName(imageFolderType: ImageFolderType): String {
+        return when (imageFolderType) {
+            ImageFolderType.ROOM -> ncpProperties.bucket.folder.roomFolder
+            ImageFolderType.PLACE -> ncpProperties.bucket.folder.placeFolder
         }
     }
 


### PR DESCRIPTION
## 이슈

장소 이미지 추가 시, 자동완성 된 이미지도 받을 수 있도록 추가했습니다.
- 수동 이미지 추가(이미지 파일 업로드) 시, 자동완성 된 이미지가 있다면 합쳐서 함께 이미지로 등록할 수 있도록 구현했습니다.
- 이미지 업로드 기능을 새로운 Usecase로 분리해서 기존 서비스 로직과 분리해 동작할 수 있도록 구현했습니다.

## 변경 사항

## 스크린샷

## 부연 설명

## 체크리스트

- [x] Lint 적용 여부
- [x] 빌드 성공 여부
- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
